### PR TITLE
Rework theme system with semantic tokens and dark adaptation

### DIFF
--- a/modules/expo-platform-colors/expo-module.config.json
+++ b/modules/expo-platform-colors/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["apple"],
+  "apple": {
+    "modules": ["PlatformColorsModule"]
+  }
+}

--- a/modules/expo-platform-colors/package.json
+++ b/modules/expo-platform-colors/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "expo-platform-colors",
+  "version": "0.1.0",
+  "description": "Resolve UIKit semantic colors to hex and force app-wide user interface style.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "private": true
+}

--- a/modules/expo-platform-colors/src/index.ts
+++ b/modules/expo-platform-colors/src/index.ts
@@ -1,0 +1,26 @@
+import { requireNativeModule } from "expo";
+
+type Scheme = "light" | "dark";
+type Override = Scheme | "system";
+
+interface NativeModule {
+  resolveSync(name: string, style: Scheme): string;
+  setOverrideUserInterfaceStyle(style: Override): void;
+}
+
+const native: NativeModule = requireNativeModule("ExpoPlatformColors");
+
+/** Resolve a UIKit semantic color name to a hex string for the given scheme. */
+export function resolveSemanticColor(name: string, scheme: Scheme): string {
+  return native.resolveSync(name, scheme);
+}
+
+/**
+ * Force the app-wide user interface style. Passing "system" clears the override
+ * and falls back to the device setting. Propagates to every window, so
+ * `@expo/ui` Host subtrees, GlassView, `useColorScheme()`, and presented
+ * sheets all follow.
+ */
+export function setOverrideUserInterfaceStyle(style: Override): void {
+  native.setOverrideUserInterfaceStyle(style);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "expo-linking": "~55.0.13",
         "expo-location": "~55.1.8",
         "expo-modules-core": "^55.0.22",
+        "expo-platform-colors": "file:./modules/expo-platform-colors",
         "expo-router": "~55.0.12",
         "expo-sharing": "~55.0.18",
         "expo-splash-screen": "~55.0.18",
@@ -78,6 +79,9 @@
         "react-test-renderer": "^19.2.0",
         "typescript": "~5.9.2"
       }
+    },
+    "modules/expo-platform-colors": {
+      "version": "0.1.0"
     },
     "node_modules/@0no-co/graphql.web": {
       "version": "1.2.0",
@@ -10855,6 +10859,10 @@
           "optional": true
         }
       }
+    },
+    "node_modules/expo-platform-colors": {
+      "resolved": "modules/expo-platform-colors",
+      "link": true
     },
     "node_modules/expo-router": {
       "version": "55.0.12",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "expo-image": "~55.0.8",
     "expo-linking": "~55.0.13",
     "expo-location": "~55.1.8",
+    "expo-platform-colors": "file:./modules/expo-platform-colors",
     "expo-modules-core": "^55.0.22",
     "expo-router": "~55.0.12",
     "expo-sharing": "~55.0.18",

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,4 +1,5 @@
 import { cancelAllDownloads } from "@/charts/download";
+import { useActiveTheme } from "@/charts/hooks/useCharts";
 import "@/import/background"; // Register import background task at module scope
 import { handleIncomingFileUrl, resumeImportIfNeeded } from "@/import/state";
 import { connectAll, disconnectAll } from "@/instruments/hooks/useConnections";
@@ -7,12 +8,21 @@ import "@/tracks/hooks/useTrackRecording"; // Register background task at module
 import { LocationManager } from "@maplibre/maplibre-react-native";
 import { DarkTheme, DefaultTheme, ThemeProvider } from "@react-navigation/native";
 import * as Linking from "expo-linking";
+import { setOverrideUserInterfaceStyle } from "expo-platform-colors";
 import { Stack } from "expo-router";
 import { useEffect } from "react";
 import { useColorScheme } from 'react-native';
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
+  const activeTheme = useActiveTheme();
+
+  // Drive the app-wide user interface style from the chart theme. This one
+  // call flips every window's trait collection, so @expo/ui Host subtrees,
+  // GlassView, useColorScheme(), and presented sheets all follow.
+  useEffect(() => {
+    setOverrideUserInterfaceStyle(activeTheme === "day" ? "light" : "dark");
+  }, [activeTheme]);
 
   // Stop native location updates and cancel active downloads before JS
   // runtime tears down on reload, preventing crashes and orphaned native tasks.
@@ -114,7 +124,7 @@ export default function RootLayout() {
         <Stack.Screen name="settings" options={{
           presentation: "formSheet",
           sheetLargestUndimmedDetentIndex: "last",
-          sheetAllowedDetents: [0.5, 1],
+          sheetAllowedDetents: [1],
           sheetGrabberVisible: true,
           title: "Settings",
         }} />

--- a/src/app/charts/[id]/index.tsx
+++ b/src/app/charts/[id]/index.tsx
@@ -84,7 +84,7 @@ export default function ChartDetail() {
             </VStack>
             <Section>
               {chart.catalogEntry ? (
-                <Text modifiers={[foregroundStyle(theme.textSecondary)]}>
+                <Text modifiers={[foregroundStyle(theme.labelSecondary)]}>
                   From catalog: {chart.catalogEntry.title}
                 </Text>
               ) : null}

--- a/src/app/charts/[id]/offline.tsx
+++ b/src/app/charts/[id]/offline.tsx
@@ -108,7 +108,7 @@ export default function OfflineSummary() {
               <HStack>
                 <Text>Total offline data</Text>
                 <Spacer />
-                <Text modifiers={[foregroundStyle(theme.textSecondary)]}>
+                <Text modifiers={[foregroundStyle(theme.labelSecondary)]}>
                   {hasAnyData ? formatBytes(totalBytes) : "None"}
                 </Text>
               </HStack>
@@ -156,7 +156,7 @@ export default function OfflineSummary() {
                       <Text modifiers={[font({ size: 15 })]}>
                         {source.title}
                       </Text>
-                      <Text modifiers={[font({ size: 12 }), foregroundStyle(theme.textSecondary)]}>
+                      <Text modifiers={[font({ size: 12 }), foregroundStyle(theme.labelSecondary)]}>
                         {source.sizeBytes ? formatBytes(source.sizeBytes) : "MBTiles"}
                       </Text>
                     </VStack>
@@ -199,7 +199,7 @@ export default function OfflineSummary() {
                       <HStack alignment="center">
                         <VStack alignment="leading" spacing={2}>
                           <Text modifiers={[font({ size: 15 })]}>Tile cache</Text>
-                          <Text modifiers={[font({ size: 12 }), foregroundStyle(theme.textSecondary)]}>
+                          <Text modifiers={[font({ size: 12 }), foregroundStyle(theme.labelSecondary)]}>
                             {state === "complete"
                               ? `${tileCount} tiles · ${formatBytes(size)}`
                               : state === "active"

--- a/src/app/charts/add.tsx
+++ b/src/app/charts/add.tsx
@@ -248,7 +248,7 @@ export default function AddChart() {
 
           {status.state === "detecting" && !hasSources ? (
             <Section>
-              <Text modifiers={[foregroundStyle(theme.textSecondary)]}>
+              <Text modifiers={[foregroundStyle(theme.labelSecondary)]}>
                 Detecting source type...
               </Text>
             </Section>
@@ -360,13 +360,13 @@ function SourceCard({
       />
 
       {"url" in source && source.url ? (
-        <Text modifiers={[foregroundStyle(theme.textSecondary)]}>
+        <Text modifiers={[foregroundStyle(theme.labelSecondary)]}>
           {source.url}
         </Text>
       ) : null}
 
       {"tiles" in source && source.tiles?.[0] ? (
-        <Text modifiers={[foregroundStyle(theme.textSecondary)]}>
+        <Text modifiers={[foregroundStyle(theme.labelSecondary)]}>
           {source.tiles[0]}
         </Text>
       ) : null}

--- a/src/app/charts/catalog/[id].tsx
+++ b/src/app/charts/catalog/[id].tsx
@@ -82,11 +82,11 @@ export default function CatalogEntryDetail() {
               </VStack>
             ) : null}
             <Section>
-              <Text modifiers={[foregroundStyle(theme.textSecondary)]}>
+              <Text modifiers={[foregroundStyle(theme.labelSecondary)]}>
                 {entry.summary}
               </Text>
               {entry.description ? (
-                <Text modifiers={[foregroundStyle(theme.textSecondary)]}>
+                <Text modifiers={[foregroundStyle(theme.labelSecondary)]}>
                   {entry.description}
                 </Text>
               ) : null}

--- a/src/app/charts/catalog/index.tsx
+++ b/src/app/charts/catalog/index.tsx
@@ -91,7 +91,7 @@ export default function ChartCatalog() {
                               style={{
                                 width: 56,
                                 height: 56,
-                                backgroundColor: theme.surfaceSecondary,
+                                backgroundColor: theme.surface,
                                 alignItems: "center",
                                 justifyContent: "center",
                               }}
@@ -111,7 +111,7 @@ export default function ChartCatalog() {
                         <Text
                           modifiers={[
                             font({ size: 13 }),
-                            foregroundStyle(theme.textSecondary),
+                            foregroundStyle(theme.labelSecondary),
                             lineLimit(2),
                           ]}
                         >
@@ -148,14 +148,14 @@ export default function ChartCatalog() {
               <HStack
                 modifiers={[onTapGesture(() => router.push("/charts/add"))]}
               >
-                <Text modifiers={[foregroundStyle(theme.primary)]}>
+                <Text modifiers={[foregroundStyle(theme.accent)]}>
                   Manually Add Chart…
                 </Text>
                 <Spacer />
                 <Image
                   systemName="chevron.right"
                   size={13}
-                  color={theme.textSecondary}
+                  color={theme.labelSecondary}
                 />
               </HStack>
             </Section>

--- a/src/app/charts/index.tsx
+++ b/src/app/charts/index.tsx
@@ -139,7 +139,7 @@ function ChartRow({
             {chart.name}
           </Text>
           {selected ? (
-            <Image systemName="checkmark" size={14} color={theme.primary} />
+            <Image systemName="checkmark" size={14} color={theme.accent} />
           ) : null}
         </HStack>
       </ContextMenu.Trigger>

--- a/src/app/marker/edit.tsx
+++ b/src/app/marker/edit.tsx
@@ -28,7 +28,7 @@ export default function EditMarkerScreen() {
   const marker = useMarker(markerId);
   const theme = useTheme();
 
-  const [color, setColor] = useState<string>(marker?.color ?? theme.primary);
+  const [color, setColor] = useState<string>(marker?.color ?? theme.accent);
   const [icon, setIcon] = useState<AnnotationIconName>((marker?.icon as AnnotationIconName) ?? "pin");
 
   const subtitle = marker
@@ -104,7 +104,7 @@ export default function EditMarkerScreen() {
                       backgroundColor: name === icon ? color : "transparent",
                     }}
                     >
-                      <AnnotationIcon name={name} size={24} color={name === icon ? theme.surface : theme.textPrimary} />
+                      <AnnotationIcon name={name} size={24} color={name === icon ? theme.surface : theme.label} />
                     </View>
                   </Pressable>
                 ))}

--- a/src/app/menu.tsx
+++ b/src/app/menu.tsx
@@ -1,13 +1,15 @@
+import useTheme from "@/hooks/useTheme";
 import { useImport } from "@/import/state";
 import { useMarkerCount } from "@/markers/hooks/useMarkers";
 import { useRouteCount } from "@/routes/hooks/useRoutes";
 import { useTrackCount } from "@/tracks/hooks/useTracks";
 import SheetView from "@/ui/SheetView";
-import { Button, Host, List, Section } from "@expo/ui/swift-ui";
+import { Button, Host, Image, Label, List, Section } from "@expo/ui/swift-ui";
 import { badge, tint } from "@expo/ui/swift-ui/modifiers";
 import { router } from "expo-router";
 
 export default function Menu() {
+  const theme = useTheme();
   const { errorCount } = useImport();
   const trackCount = useTrackCount();
   const markerCount = useMarkerCount();
@@ -23,23 +25,53 @@ export default function Menu() {
         <List>
           <Section>
             <Button
-              modifiers={[tint('primary'), badge(trackCount > 0 ? String(trackCount) : undefined)]}
-              systemImage="point.bottomleft.forward.to.arrow.triangle.scurvepath"
-              label="Tracks"
+              modifiers={[
+                tint('primary'),
+                badge(trackCount > 0 ? String(trackCount) : undefined)
+              ]}
               onPress={() => router.dismissTo("/tracks")}
-            />
+            >
+              <Label
+                title="Tracks"
+                icon={
+                  <Image
+                    systemName="point.bottomleft.forward.to.arrow.triangle.scurvepath"
+                    size={18}
+                    color={theme.tracks}
+                  />
+                }
+              />
+            </Button>
             <Button
               modifiers={[tint('primary'), badge(markerCount > 0 ? String(markerCount) : undefined)]}
-              systemImage="mappin.and.ellipse"
-              label="Markers"
               onPress={() => router.dismissTo("/markers")}
-            />
+            >
+              <Label
+                title="Markers"
+                icon={
+                  <Image
+                    systemName="mappin.and.ellipse"
+                    size={18}
+                    color={theme.markers}
+                  />
+                }
+              />
+            </Button>
             <Button
               modifiers={[tint('primary'), badge(routeCount > 0 ? String(routeCount) : undefined)]}
-              systemImage="point.topright.arrow.triangle.backward.to.point.bottomleft.scurvepath.fill"
-              label="Routes"
               onPress={() => router.dismissTo("/routes")}
-            />
+            >
+              <Label
+                title="Routes"
+                icon={
+                  <Image
+                    systemName="point.topright.arrow.triangle.backward.to.point.bottomleft.scurvepath.fill"
+                    size={18}
+                    color={theme.routes}
+                  />
+                }
+              />
+            </Button>
           </Section>
           <Section>
             <Button

--- a/src/app/offline/index.tsx
+++ b/src/app/offline/index.tsx
@@ -109,7 +109,7 @@ export default function OfflineManagement() {
               <HStack>
                 <Text>Offline data</Text>
                 <Spacer />
-                <Text modifiers={[foregroundStyle(theme.textSecondary)]}>
+                <Text modifiers={[foregroundStyle(theme.labelSecondary)]}>
                   {formatBytes(totalStorageUsed)}
                 </Text>
               </HStack>
@@ -117,13 +117,13 @@ export default function OfflineManagement() {
                 <HStack>
                   <Text>Free space</Text>
                   <Spacer />
-                  <Text modifiers={[foregroundStyle(theme.textSecondary)]}>
+                  <Text modifiers={[foregroundStyle(theme.labelSecondary)]}>
                     {formatBytes(freeSpace)}
                   </Text>
                 </HStack>
               ) : null}
               {activeDownloadCount > 0 ? (
-                <Text modifiers={[foregroundStyle(theme.primary)]}>
+                <Text modifiers={[foregroundStyle(theme.accent)]}>
                   {activeDownloadCount} download{activeDownloadCount > 1 ? "s" : ""} in progress
                 </Text>
               ) : null}
@@ -146,7 +146,7 @@ export default function OfflineManagement() {
                         <Text
                           modifiers={[
                             font({ size: 12 }),
-                            foregroundStyle(theme.textSecondary),
+                            foregroundStyle(theme.labelSecondary),
                           ]}
                         >
                           {source.sizeBytes
@@ -191,7 +191,7 @@ export default function OfflineManagement() {
 
             {chartOfflineData.length === 0 ? (
               <Section>
-                <Text modifiers={[foregroundStyle(theme.textSecondary)]}>
+                <Text modifiers={[foregroundStyle(theme.labelSecondary)]}>
                   No offline data downloaded yet. Open a chart and download
                   regions or cache tiles for offline use.
                 </Text>
@@ -259,7 +259,7 @@ function TilePackRow({
       <VStack alignment="leading" spacing={2}>
         <Text modifiers={[font({ size: 15 })]}>Tile cache</Text>
         <Text
-          modifiers={[font({ size: 12 }), foregroundStyle(theme.textSecondary)]}
+          modifiers={[font({ size: 12 }), foregroundStyle(theme.labelSecondary)]}
         >
           {label}
         </Text>

--- a/src/charts/components/DownloadRegionOverlay.tsx
+++ b/src/charts/components/DownloadRegionOverlay.tsx
@@ -1,6 +1,6 @@
 import { useDownloadOverlay } from "@/charts/hooks/useDownloadOverlay";
 import { useTopSheetHeight } from "@/map/hooks/useSheetPosition";
-import useTheme from "@/hooks/useTheme";
+import { createStyles } from "@/hooks/useStyles";
 import { Dimensions, StyleSheet, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Svg, { Path } from "react-native-svg";
@@ -10,7 +10,7 @@ const BORDER_RADIUS = 16;
 
 export function DownloadRegionOverlay() {
   const { visible } = useDownloadOverlay();
-  const theme = useTheme();
+  const styles = useStyles();
   const insets = useSafeAreaInsets();
   const sheetHeight = useTopSheetHeight();
 
@@ -55,12 +55,11 @@ export function DownloadRegionOverlay() {
             left: rectX,
             width: rectW,
             height: rectH,
-            borderColor: theme.primary,
             borderRadius: r,
           },
         ]}
       >
-        <View style={[styles.label, { backgroundColor: theme.primary }]}>
+        <View style={styles.label}>
           <Text style={styles.labelText}>Select Download Area</Text>
         </View>
       </View>
@@ -68,10 +67,11 @@ export function DownloadRegionOverlay() {
   );
 }
 
-const styles = StyleSheet.create({
+const useStyles = createStyles((theme) => ({
   border: {
     position: "absolute",
     borderWidth: 3,
+    borderColor: theme.accent,
     justifyContent: "center",
     alignItems: "center",
   },
@@ -79,10 +79,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 6,
     borderRadius: 8,
+    backgroundColor: theme.accent,
   },
-  labelText: {
-    color: "#fff",
-    fontSize: 14,
-    fontWeight: "600",
-  },
-});
+  labelText: { color: theme.contrast, fontSize: 14, fontWeight: "600" },
+}));

--- a/src/charts/components/OfflineStatusButton.tsx
+++ b/src/charts/components/OfflineStatusButton.tsx
@@ -65,7 +65,7 @@ export function OfflineStatusButton() {
       ? theme.success
       : status === "partial"
         ? theme.warning
-        : undefined;
+        : "primary";
 
   return (
     <Button

--- a/src/charts/components/SelectChartButton.tsx
+++ b/src/charts/components/SelectChartButton.tsx
@@ -2,12 +2,11 @@ import { useCharts } from "@/charts/hooks/useCharts";
 import { selectChart } from "@/charts/store";
 import { Button, Divider, Menu } from "@expo/ui/swift-ui";
 import {
-  contentShape,
+  foregroundStyle,
   frame,
   glassEffect,
   glassEffectId,
-  labelStyle,
-  shapes,
+  labelStyle
 } from "@expo/ui/swift-ui/modifiers";
 import { router } from "expo-router";
 
@@ -22,9 +21,9 @@ export function SelectChartButton() {
       systemImage={"square.3.layers.3d"}
       modifiers={[
         labelStyle("iconOnly"),
+        foregroundStyle("primary"),
         frame({ width: 44, height: 44 }),
-        contentShape(shapes.circle()),
-        glassEffect({ glass: { variant: "regular" }, shape: "circle" }),
+        glassEffect({ glass: { variant: "regular", interactive: true }, shape: "circle" }),
         glassEffectId("chart-type", NS_ID),
       ]}
     >

--- a/src/hooks/useStyles.ts
+++ b/src/hooks/useStyles.ts
@@ -1,0 +1,29 @@
+import useTheme, { type Theme } from "@/hooks/useTheme";
+import { useMemo } from "react";
+import { StyleSheet, type ImageStyle, type TextStyle, type ViewStyle } from "react-native";
+
+type NamedStyles<T> = { [P in keyof T]: ViewStyle | TextStyle | ImageStyle };
+
+/**
+ * Builds a memoized StyleSheet keyed on the active theme. Use for styles that
+ * reference theme tokens; plain `StyleSheet.create` is still fine for
+ * layout-only styles.
+ *
+ *   const useStyles = createStyles((theme) => ({
+ *     container: { backgroundColor: theme.background },
+ *     label: { color: theme.label },
+ *   }));
+ *
+ *   function Foo() {
+ *     const styles = useStyles();
+ *     return <View style={styles.container} />;
+ *   }
+ */
+export function createStyles<T extends NamedStyles<T>>(
+  factory: (theme: Theme) => T,
+): () => T {
+  return function useStyles() {
+    const theme = useTheme();
+    return useMemo(() => StyleSheet.create(factory(theme)), [theme]);
+  };
+}

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -1,29 +1,185 @@
-import { PlatformColor, useColorScheme } from "react-native";
+import { resolveSemanticColor } from "expo-platform-colors";
+import { useCallback } from "react";
+import { useColorScheme } from "react-native";
 
-export default function useTheme(colorScheme?: "light" | "dark") {
-  const systemScheme = useColorScheme() as "light" | "dark" | null;
-  const isDark = (colorScheme ?? systemScheme ?? "light") === "dark";
+/**
+ * Theme tokens are named by role. UIKit-backed tokens borrow their value from
+ * the corresponding `UIColor` semantic color; app-specific tokens either
+ * declare an explicit light/dark pair or a single canonical hex whose dark
+ * variant is derived via the HSL adaptation below.
+ */
+type Token =
+  | { ios: string }
+  | { custom: string }
+  | { custom: { light: string; dark: string } };
 
-  return {
-    background: isDark ? "#000000" : "#f2f2f7",
-    surface: isDark ? "#1c1c1e" : "#ffffff",
-    surfaceSecondary: isDark ? "#2c2c2e" : "#f1f5f9",
-    textPrimary: isDark ? "#ffffff" : "#1a1a1a",
-    textSecondary: PlatformColor("secondaryLabel"),
-    textTertiary: isDark ? "#71717a" : "#94a3b8",
-    primary: isDark ? "#007AFF" : "#0066CC",
-    success: isDark ? "#30d158" : "#22c55e",
-    warning: isDark ? "#ff9f0a" : "#f59e0b",
-    danger: isDark ? "#ff453a" : "#ef4444",
-    buttonBackground: isDark ? "#3a3a3c" : "#e2e8f0",
-    buttonBackgroundActive: isDark ? "#30d158" : "#22c55e",
-    border: PlatformColor("opaqueSeparator"),
-    borderActive: isDark ? "#30d158" : "#16a34a",
-    shadowColor: isDark ? "rgba(0, 0, 0, 0.6)" : "rgba(0, 0, 0, 0.3)",
-    glowColor: isDark ? "rgba(48, 209, 88, 0.4)" : "rgba(34, 197, 94, 0.3)",
-    primaryGlow: isDark ? "rgba(0, 122, 255, 0.4)" : "rgba(0, 102, 204, 0.3)",
-    // Semi-transparent card/panel backgrounds that float above map content
-    surfaceElevated: isDark ? "rgba(44, 44, 46, 0.9)" : "rgba(255, 255, 255, 0.85)",
-    userLocation: isDark ? "#ff453a" : "#ef4444",
-  };
+const tokens = {
+  // ── Backgrounds ───────────────────────────────────────────
+  // Surfaces you paint on, from back to front.
+  background: { ios: "systemBackground" },
+  surface: { ios: "secondarySystemBackground" },
+  surfaceFloating: {
+    custom: {
+      light: "rgba(255, 255, 255, 0.85)",
+      dark: "rgba(44, 44, 46, 0.9)",
+    },
+  },
+
+  // ── Foregrounds ───────────────────────────────────────────
+  // "label" family: text/icons on a background or surface.
+  label: { ios: "label" },
+  labelSecondary: { ios: "secondaryLabel" },
+  labelTertiary: { ios: "tertiaryLabel" },
+  // "contrast": foreground on any saturated fill (accent or map overlay)
+  // or on the nautical chart.
+  contrast: { custom: "#FFFFFF" },
+
+  // ── Accents ───────────────────────────────────────────────
+  // Saturated role colors for UI fills.
+  accent: { ios: "systemBlue" },
+  success: { ios: "systemGreen" },
+  warning: { ios: "systemOrange" },
+  danger: { ios: "systemRed" },
+
+  // ── Map features ──────────────────────────────────────────
+  // Saturated app-specific colors for map overlays. Single hex — dark
+  // variant auto-derived via HSL adaptation.
+  userLocation: { ios: "systemRed" },
+  tracks: { custom: "#FF3B30" },
+  routes: { custom: "#EE22EE" },
+  markers: { custom: "#007AFF" },
+  ais: { custom: "#22C55E" },
+  aton: { custom: "#F59E0B" },
+
+  // ── Chrome ────────────────────────────────────────────────
+  separator: { ios: "opaqueSeparator" },
+  fill: { ios: "systemFill" },
+} satisfies Record<string, Token>;
+
+type Scheme = "light" | "dark";
+type Palette = { readonly [K in keyof typeof tokens]: string };
+
+export type Theme = Palette & {
+  /**
+   * Returns a scheme-adjusted version of an arbitrary hex color. In light
+   * mode returns the input unchanged; in dark mode reduces lightness and
+   * saturation via HSL so saturated colors don't stab at night. Used both
+   * for user-picked colors at runtime and for deriving dark variants of
+   * single-value theme tokens at module load.
+   */
+  adapt: (hex: string) => string;
 };
+
+// ── Color adaptation ──────────────────────────────────────────
+// HSL transform applied to any saturated hex in dark mode. Multipliers
+// chosen so a saturated mid-tone reads as "quieter same color" in dark,
+// without crushing blues/greens to near-black.
+const DARK_SATURATION = 0.95;
+const DARK_LIGHTNESS = 0.5;
+
+const adaptCache = new Map<string, string>();
+
+function adaptColor(hex: string, scheme: Scheme): string {
+  if (scheme === "light") return hex;
+  const key = `${scheme}:${hex}`;
+  const cached = adaptCache.get(key);
+  if (cached) return cached;
+  const rgb = parseHex(hex);
+  if (!rgb) return hex;
+  const { h, s, l } = rgbToHsl(rgb);
+  const out = hslToHex({
+    h,
+    s: clamp01(s * DARK_SATURATION),
+    l: clamp01(l * DARK_LIGHTNESS),
+  });
+  adaptCache.set(key, out);
+  return out;
+}
+
+function parseHex(hex: string): { r: number; g: number; b: number } | null {
+  const m = hex.trim().match(/^#?([\da-f]{3}|[\da-f]{6})$/i);
+  if (!m) return null;
+  const h = m[1].length === 3 ? m[1].replace(/./g, (c) => c + c) : m[1];
+  return {
+    r: parseInt(h.slice(0, 2), 16) / 255,
+    g: parseInt(h.slice(2, 4), 16) / 255,
+    b: parseInt(h.slice(4, 6), 16) / 255,
+  };
+}
+
+function rgbToHsl({ r, g, b }: { r: number; g: number; b: number }) {
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  if (max === min) return { h: 0, s: 0, l };
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h: number;
+  switch (max) {
+    case r: h = ((g - b) / d + (g < b ? 6 : 0)) / 6; break;
+    case g: h = ((b - r) / d + 2) / 6; break;
+    default: h = ((r - g) / d + 4) / 6;
+  }
+  return { h, s, l };
+}
+
+function hslToHex({ h, s, l }: { h: number; s: number; l: number }): string {
+  let r: number, g: number, b: number;
+  if (s === 0) {
+    r = g = b = l;
+  } else {
+    const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+    const p = 2 * l - q;
+    r = hueToRgb(p, q, h + 1 / 3);
+    g = hueToRgb(p, q, h);
+    b = hueToRgb(p, q, h - 1 / 3);
+  }
+  const toHex = (v: number) =>
+    Math.round(clamp01(v) * 255).toString(16).padStart(2, "0");
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function hueToRgb(p: number, q: number, t: number): number {
+  if (t < 0) t += 1;
+  if (t > 1) t -= 1;
+  if (t < 1 / 6) return p + (q - p) * 6 * t;
+  if (t < 1 / 2) return q;
+  if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+  return p;
+}
+
+function clamp01(v: number): number {
+  return Math.max(0, Math.min(1, v));
+}
+
+// ── Palette materialization ───────────────────────────────────
+function resolve(token: Token, scheme: Scheme): string {
+  if ("ios" in token) return resolveSemanticColor(token.ios, scheme);
+  if (typeof token.custom === "string") return adaptColor(token.custom, scheme);
+  return token.custom[scheme];
+}
+
+function build(scheme: Scheme): Palette {
+  const entries = (Object.keys(tokens) as (keyof typeof tokens)[]).map(
+    (name) => [name, resolve(tokens[name], scheme)] as const,
+  );
+  return Object.freeze(Object.fromEntries(entries)) as Palette;
+}
+
+/** Materialized once at module load; static for the lifetime of the JS runtime. */
+const palettes = Object.freeze({
+  light: build("light"),
+  dark: build("dark"),
+});
+
+/**
+ * Returns the active color palette. The window's user interface style is
+ * driven app-wide by `setOverrideUserInterfaceStyle` (wired to the chart
+ * theme), so `useColorScheme()` reflects the app theme rather than the OS
+ * setting.
+ */
+export default function useTheme(): Theme {
+  const scheme: Scheme = useColorScheme() === "dark" ? "dark" : "light";
+  const adapt = useCallback((hex: string) => adaptColor(hex, scheme), [scheme]);
+  return { ...palettes[scheme], adapt };
+}

--- a/src/hooks/useTheme.tsx
+++ b/src/hooks/useTheme.tsx
@@ -1,5 +1,4 @@
 import { resolveSemanticColor } from "expo-platform-colors";
-import { useCallback } from "react";
 import { useColorScheme } from "react-native";
 
 /**
@@ -167,9 +166,15 @@ function build(scheme: Scheme): Palette {
 }
 
 /** Materialized once at module load; static for the lifetime of the JS runtime. */
-const palettes = Object.freeze({
-  light: build("light"),
-  dark: build("dark"),
+const themes = Object.freeze({
+  light: Object.freeze({
+    ...build("light"),
+    adapt: (hex: string) => adaptColor(hex, "light"),
+  }),
+  dark: Object.freeze({
+    ...build("dark"),
+    adapt: (hex: string) => adaptColor(hex, "dark"),
+  }),
 });
 
 /**
@@ -177,9 +182,10 @@ const palettes = Object.freeze({
  * driven app-wide by `setOverrideUserInterfaceStyle` (wired to the chart
  * theme), so `useColorScheme()` reflects the app theme rather than the OS
  * setting.
+ *
+ * Returns the same object identity for a given scheme so memoized consumers
+ * (like `createStyles`) don't re-evaluate on every render.
  */
 export default function useTheme(): Theme {
-  const scheme: Scheme = useColorScheme() === "dark" ? "dark" : "light";
-  const adapt = useCallback((hex: string) => adaptColor(hex, scheme), [scheme]);
-  return { ...palettes[scheme], adapt };
+  return useColorScheme() === "dark" ? themes.dark : themes.light;
 }

--- a/src/map/components/Annotation.tsx
+++ b/src/map/components/Annotation.tsx
@@ -1,8 +1,9 @@
 import useTheme from "@/hooks/useTheme";
+import { createStyles } from "@/hooks/useStyles";
 import { ViewAnnotation, type ViewAnnotationProps } from "@maplibre/maplibre-react-native";
 import * as Haptics from "expo-haptics";
 import { ReactNode, useCallback, useEffect, useRef } from "react";
-import { StyleSheet, View } from "react-native";
+import { View } from "react-native";
 import Animated, {
   interpolate,
   useAnimatedStyle,
@@ -43,6 +44,7 @@ export function Annotation({
   ...props
 }: AnnotationProps) {
   const theme = useTheme();
+  const styles = useStyles();
   const prevSelected = useRef(selected);
 
   // --- Animations ---
@@ -162,16 +164,16 @@ export function Annotation({
     >
       <>
         <Animated.View style={containerStyle}>
-          <Animated.View style={[styles.circle, { backgroundColor: color, borderColor: theme.surface }, circleSize]}>
+          <Animated.View style={[styles.circle, { backgroundColor: color }, circleSize]}>
             <Animated.View style={iconStyle}>
               {label != null ? (
                 <Animated.Text style={styles.label}>{label}</Animated.Text>
               ) : icon ? (
-                <AnnotationIcon name={icon} color="white" size={26} />
+                <AnnotationIcon name={icon} color={theme.contrast} size={26} />
               ) : null}
             </Animated.View>
           </Animated.View>
-          <Animated.View style={[styles.tail, { borderTopColor: theme.surface }, tailStyle]} />
+          <Animated.View style={[styles.tail, tailStyle]} />
         </Animated.View>
         {selected && accessory && (
           <View style={styles.accessory} pointerEvents="box-none">
@@ -184,10 +186,11 @@ export function Annotation({
 }
 
 
-const styles = StyleSheet.create({
+const useStyles = createStyles((theme) => ({
   circle: {
     alignItems: "center",
     justifyContent: "center",
+    borderColor: theme.contrast,
   },
   // With anchor="center", the container's vertical center is the coordinate,
   // so top:"50%" anchors the accessory's top at the coord point. Absolute
@@ -207,12 +210,13 @@ const styles = StyleSheet.create({
     borderLeftColor: "transparent",
     borderRightWidth: 9,
     borderRightColor: "transparent",
+    borderTopColor: theme.contrast,
   },
   label: {
-    color: "white",
+    color: theme.contrast,
     fontSize: 22,
     fontWeight: "900",
     textAlign: "center",
     letterSpacing: -0.5,
   },
-});
+}));

--- a/src/map/components/AnnotationIcon.tsx
+++ b/src/map/components/AnnotationIcon.tsx
@@ -74,5 +74,5 @@ export function AnnotationIcon({ name, color, size = 24 }: AnnotationIconProps) 
   const theme = useTheme();
   const Icon = ICONS[name] ?? ICONS.pin;
 
-  return <Icon width={size} height={size} color={color ?? theme.textPrimary} />;
+  return <Icon width={size} height={size} color={color ?? theme.label} />;
 }

--- a/src/map/components/LocationDetail.tsx
+++ b/src/map/components/LocationDetail.tsx
@@ -97,7 +97,7 @@ export default function LocationDetail({ id }: { id: string }) {
                 <Image
                   systemName="location.fill"
                   size={14}
-                  color={theme.textSecondary}
+                  color={theme.labelSecondary}
                 />
                 <Text modifiers={[
                   font({ size: 15, weight: "medium" }),
@@ -115,14 +115,14 @@ export default function LocationDetail({ id }: { id: string }) {
               <VStack alignment="leading" spacing={8}>
                 <Text modifiers={[
                   font({ size: 12, weight: "semibold" }),
-                  foregroundStyle(theme.textSecondary),
+                  foregroundStyle(theme.labelSecondary),
                 ]}>
                   CHART FEATURES
                 </Text>
                 {features.map((feature, i) => (
                   <VStack key={i} alignment="leading" spacing={4} modifiers={[
                     padding({ all: 12 }),
-                    background(theme.surfaceElevated),
+                    background(theme.surfaceFloating),
                     cornerRadius(10),
                   ]}>
                     {Object.entries(feature.properties ?? {})
@@ -132,13 +132,13 @@ export default function LocationDetail({ id }: { id: string }) {
                         <HStack key={key} spacing={4}>
                           <Text modifiers={[
                             font({ size: 14 }),
-                            foregroundStyle(theme.textSecondary),
+                            foregroundStyle(theme.labelSecondary),
                           ]}>
                             {`${key}: `}
                           </Text>
                           <Text modifiers={[
                             font({ size: 14 }),
-                            foregroundStyle(theme.textPrimary),
+                            foregroundStyle(theme.label),
                           ]}>
                             {String(value)}
                           </Text>

--- a/src/map/components/SelectedLocationAnnotation.tsx
+++ b/src/map/components/SelectedLocationAnnotation.tsx
@@ -26,7 +26,7 @@ export default function SelectedLocationAnnotation() {
       id="selected-location"
       lngLat={selectedCoords}
       icon="pin"
-      color={theme.danger}
+      color={theme.userLocation}
       selected
       draggable
       onDragEnd={handleDragEnd}

--- a/src/markers/components/MarkerListItem.tsx
+++ b/src/markers/components/MarkerListItem.tsx
@@ -2,6 +2,7 @@ import type { Marker } from "@/database";
 import { formatBearing } from "@/geo";
 import { toDistance } from "@/hooks/usePreferredUnits";
 import useTheme from "@/hooks/useTheme";
+import { createStyles } from "@/hooks/useStyles";
 import { AnnotationIcon } from "@/map/components/AnnotationIcon";
 import { deleteMarker, updateMarker } from "@/markers/hooks/useMarkers";
 import { getPosition } from "@/navigation/hooks/useNavigation";
@@ -13,7 +14,6 @@ import {
   Alert,
   PlatformColor,
   Pressable,
-  StyleSheet,
   Text,
   View,
 } from "react-native";
@@ -82,6 +82,7 @@ type Props = {
 const MarkerListItem = memo(
   function MarkerListItem({ marker }: Props) {
     const theme = useTheme();
+    const styles = useStyles();
     const distLabel = getDistanceLabel(marker);
     const coordsLabel = formatCoords(marker.latitude, marker.longitude);
 
@@ -102,35 +103,20 @@ const MarkerListItem = memo(
         <View
           style={[
             styles.icon,
-            { backgroundColor: marker.color ?? theme.primary },
+            { backgroundColor: marker.color ? theme.adapt(marker.color) : theme.markers },
           ]}
         >
-          <AnnotationIcon
-            name={marker.icon ?? "pin"}
-            color="white"
-            size={18}
-          />
+          <AnnotationIcon name={marker.icon ?? "pin"} color={theme.contrast} size={18} />
         </View>
 
         <View style={styles.content}>
           <View style={styles.topRow}>
-            <Text
-              style={[styles.title, { color: theme.textPrimary }]}
-              numberOfLines={1}
-            >
+            <Text style={styles.title} numberOfLines={1}>
               {markerDisplayName(marker)}
             </Text>
-            {distLabel && (
-              <Text
-                style={[styles.distance, { color: theme.textSecondary }]}
-              >
-                {distLabel}
-              </Text>
-            )}
+            {distLabel && <Text style={styles.distance}>{distLabel}</Text>}
           </View>
-          <Text style={[styles.coords, { color: theme.textSecondary }]}>
-            {coordsLabel}
-          </Text>
+          <Text style={styles.coords}>{coordsLabel}</Text>
         </View>
       </Pressable>
     );
@@ -146,7 +132,7 @@ const MarkerListItem = memo(
 
 export default MarkerListItem;
 
-const styles = StyleSheet.create({
+const useStyles = createStyles((theme) => ({
   row: {
     flexDirection: "row",
     alignItems: "center",
@@ -161,23 +147,22 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
-  content: {
-    flex: 1,
-    gap: 2,
-  },
+  content: { flex: 1, gap: 2 },
   topRow: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
     gap: 8,
   },
-  title: { fontSize: 16, fontWeight: "600", flexShrink: 1 },
+  title: { fontSize: 16, fontWeight: "600", flexShrink: 1, color: theme.label },
   distance: {
     fontSize: 13,
     fontVariant: ["tabular-nums"],
+    color: theme.labelSecondary,
   },
   coords: {
     fontSize: 12,
     fontVariant: ["tabular-nums"],
+    color: theme.labelSecondary,
   },
-});
+}));

--- a/src/markers/components/MarkerOverlay.tsx
+++ b/src/markers/components/MarkerOverlay.tsx
@@ -30,7 +30,7 @@ export default function MarkerOverlay() {
       properties: {
         id: marker.id,
         icon: markerIconImage(marker.icon),
-        color: marker.color ?? theme.primary,
+        color: marker.color ? theme.adapt(marker.color) : theme.markers,
       },
       geometry: {
         type: "Point" as const,
@@ -38,7 +38,7 @@ export default function MarkerOverlay() {
       },
     }));
     return { type: "FeatureCollection", features };
-  }, [markers, theme.primary]);
+  }, [markers, theme.markers, theme.adapt]);
 
   const handlePress = useCallback(
     (e: NativeSyntheticEvent<{ features: GeoJSON.Feature[] }>) => {
@@ -72,7 +72,7 @@ export default function MarkerOverlay() {
             "circle-radius": [
               "interpolate", ["linear"], ["zoom"],
               4, 4,
-              18, 18,
+              18, 12,
             ],
             "circle-color": ["get", "color"],
             "circle-stroke-width": [
@@ -80,10 +80,10 @@ export default function MarkerOverlay() {
               4, 0.2,
               18, 2,
             ],
-            "circle-stroke-color": "white",
+            "circle-stroke-color": theme.contrast,
           }}
         />
-        {/* Unselected: white icon on top of circle */}
+        {/* Unselected: contrast-colored icon on top of circle */}
         <Layer
           id="markers-symbol"
           type="symbol"
@@ -97,13 +97,13 @@ export default function MarkerOverlay() {
             "icon-size": [
               "interpolate", ["linear"], ["zoom"],
               4, 0.1,
-              18, 0.6,
+              18, 0.4,
             ],
             "icon-allow-overlap": true,
             "icon-ignore-placement": true,
           }}
           paint={{
-            "icon-color": "white",
+            "icon-color": theme.contrast,
           }}
         />
       </GeoJSONSource>
@@ -116,7 +116,7 @@ export default function MarkerOverlay() {
           id="selected-marker"
           lngLat={[selectedMarker.longitude, selectedMarker.latitude]}
           icon={selectedMarker.icon ?? "pin"}
-          color={selectedMarker.color ?? theme.primary}
+          color={selectedMarker.color ? theme.adapt(selectedMarker.color) : theme.markers}
           selected
           draggable
           onPress={() => navigate("marker", String(selectedMarker.id))}

--- a/src/navigation/components/HeadsUpDisplay.tsx
+++ b/src/navigation/components/HeadsUpDisplay.tsx
@@ -1,21 +1,20 @@
-
-import { NavigationState, useNavigation } from "@/navigation/hooks/useNavigation";
 import { toSpeed } from "@/hooks/usePreferredUnits";
-import useTheme from "@/hooks/useTheme";
+import { createStyles } from "@/hooks/useStyles";
+import { NavigationState, useNavigation } from "@/navigation/hooks/useNavigation";
 import { useTrackRecording } from "@/tracks/hooks/useTrackRecording";
-import { StyleSheet, Text, View } from "react-native";
 import OverlayView from "@/ui/OverlayView";
+import { Text, View } from "react-native";
 
 function SpeedOverGround() {
   const nav = useNavigation();
-  const theme = useTheme();
+  const styles = useStyles();
   const { value, plural } = toSpeed(nav.speed ?? undefined);
 
   return (
     <View style={styles.section}>
-      <Text style={[{ color: theme.textPrimary }, styles.sectionLabel]}>SOG</Text>
-      <Text style={[{ color: theme.textPrimary }, styles.sectionValue]}>{value ?? "--"}</Text>
-      <Text style={[{ color: theme.textPrimary }, styles.sectionUnits]}>{plural}</Text>
+      <Text style={styles.sectionLabel}>SOG</Text>
+      <Text style={styles.sectionValue}>{value ?? "--"}</Text>
+      <Text style={styles.sectionUnits}>{plural}</Text>
     </View>
   );
 }
@@ -23,6 +22,7 @@ function SpeedOverGround() {
 export default function HeadsUpDisplay() {
   const nav = useNavigation();
   const { isRecording } = useTrackRecording();
+  const styles = useStyles();
 
   const visible = nav.state === NavigationState.Underway || isRecording;
   if (!visible) return null;
@@ -34,7 +34,7 @@ export default function HeadsUpDisplay() {
   );
 }
 
-const styles = StyleSheet.create({
+const useStyles = createStyles((theme) => ({
   container: {
     alignItems: "center",
     paddingVertical: 8,
@@ -42,19 +42,19 @@ const styles = StyleSheet.create({
     borderRadius: 20,
     minWidth: 100,
   },
-  section: {
-    alignItems: "center",
-  },
+  section: { alignItems: "center" },
   sectionLabel: {
     fontSize: 11,
     fontWeight: "600",
     textTransform: "uppercase",
     opacity: 0.6,
+    color: theme.label,
   },
   sectionUnits: {
     fontSize: 10,
     textTransform: "uppercase",
     opacity: 0.6,
+    color: theme.label,
   },
   sectionValue: {
     fontSize: 24,
@@ -62,5 +62,6 @@ const styles = StyleSheet.create({
     textAlign: "center",
     letterSpacing: -0.8,
     fontVariant: ["tabular-nums"],
+    color: theme.label,
   },
-});
+}));

--- a/src/navigation/components/NavigationHUD.tsx
+++ b/src/navigation/components/NavigationHUD.tsx
@@ -1,5 +1,6 @@
 import { toDepth, toSpeed, toTemperature } from "@/hooks/usePreferredUnits";
 import useTheme from "@/hooks/useTheme";
+import { createStyles } from "@/hooks/useStyles";
 import { type DataPoint, useHasInstrumentData, useInstrumentPath } from "@/instruments/hooks/useInstruments";
 import { NavigationState, useNavigation } from "@/navigation/hooks/useNavigation";
 import { useTrackRecording } from "@/tracks/hooks/useTrackRecording";
@@ -7,7 +8,7 @@ import OverlayView from "@/ui/OverlayView";
 import * as Haptics from "expo-haptics";
 import { SymbolView } from "expo-symbols";
 import { useState } from "react";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import { Pressable, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 const STALE_THRESHOLD = 10_000; // 10 seconds
@@ -29,17 +30,17 @@ type CellProps = {
 };
 
 function Cell({ label, value, unit, stale = false }: CellProps) {
-  const theme = useTheme();
+  const styles = useStyles();
   return (
     <View style={styles.cell}>
-      <Text style={[styles.cellLabel, { color: theme.textPrimary, opacity: stale ? 0.3 : 0.6 }]}>
+      <Text style={[styles.cellLabel, { opacity: stale ? 0.3 : 0.6 }]}>
         {label}
       </Text>
       <View style={{ flexDirection: "row", alignItems: "flex-end" }}>
-        <Text style={[styles.cellValue, { color: theme.textPrimary, opacity: stale ? 0.3 : 1 }]}>
+        <Text style={[styles.cellValue, { opacity: stale ? 0.3 : 1 }]}>
           {value}
         </Text>
-        <Text style={[styles.cellUnit, { color: theme.textPrimary, opacity: stale ? 0.3 : 0.6 }]}>
+        <Text style={[styles.cellUnit, { opacity: stale ? 0.3 : 0.6 }]}>
           {unit}
         </Text>
       </View>
@@ -74,6 +75,7 @@ export default function NavigationHUD() {
 
   const hasInstruments = useHasInstrumentData();
   const theme = useTheme();
+  const styles = useStyles();
 
   // Visible when underway, recording, or instrument data exists
   const visible = navState === NavigationState.Underway || isRecording || hasInstruments;
@@ -91,7 +93,7 @@ export default function NavigationHUD() {
           {/* Source indicator */}
           {navSource === "signalk" && (
             <View style={styles.sourceRow}>
-              <SymbolView name="antenna.radiowaves.left.and.right" size={10} tintColor={theme.textSecondary} />
+              <SymbolView name="antenna.radiowaves.left.and.right" size={10} tintColor={theme.labelSecondary} />
             </View>
           )}
 
@@ -161,7 +163,7 @@ export default function NavigationHUD() {
   );
 }
 
-const styles = StyleSheet.create({
+const useStyles = createStyles((theme) => ({
   container: {
     position: "absolute",
     top: 0,
@@ -170,32 +172,21 @@ const styles = StyleSheet.create({
     alignItems: "center",
     paddingBottom: 16,
   },
-  sourceRow: {
-    alignItems: "center",
-  },
+  sourceRow: { alignItems: "center" },
   row: {
     flexDirection: "row",
     justifyContent: "space-around",
     gap: 16,
   },
-  cell: {
-    alignItems: "center",
-    minWidth: 56,
-    paddingVertical: 2,
-  },
-  cellLabel: {
-    fontSize: 14,
-    textTransform: "uppercase",
-  },
+  cell: { alignItems: "center", minWidth: 56, paddingVertical: 2 },
+  cellLabel: { fontSize: 14, textTransform: "uppercase", color: theme.label },
   cellValue: {
     fontSize: 22,
     fontWeight: "700",
     textAlign: "center",
     letterSpacing: -0.8,
     fontVariant: ["tabular-nums"],
+    color: theme.label,
   },
-  cellUnit: {
-    fontSize: 9,
-    textTransform: "uppercase",
-  },
-});
+  cellUnit: { fontSize: 9, textTransform: "uppercase", color: theme.label },
+}));

--- a/src/navigation/components/NavigationPuck.tsx
+++ b/src/navigation/components/NavigationPuck.tsx
@@ -1,6 +1,6 @@
-import { useNavigation } from "@/navigation/hooks/useNavigation";
-import useTheme from "@/hooks/useTheme";
 import { projectPosition } from "@/geo";
+import useTheme from "@/hooks/useTheme";
+import { useNavigation } from "@/navigation/hooks/useNavigation";
 import { Layer, Animated as MLAnimated } from "@maplibre/maplibre-react-native";
 import { memo, useEffect, useMemo, useRef } from "react";
 import { Easing, Animated as RNAnimated } from "react-native";
@@ -214,7 +214,7 @@ export const NavigationPuck = memo(function NavigationPuck() {
           }}
           paint={{
             "icon-color": theme.userLocation,
-            "icon-halo-color": theme.surface,
+            "icon-halo-color": theme.contrast,
             "icon-halo-width": 1.5,
           }}
         />

--- a/src/routes/components/RouteButton.tsx
+++ b/src/routes/components/RouteButton.tsx
@@ -14,7 +14,7 @@ export default function RouteButton({ latitude, longitude }: Props) {
   return (
     <Stack.Toolbar.Button
       icon="point.topright.arrow.triangle.backward.to.point.bottomleft.scurvepath.fill"
-      tintColor={isActive ? theme.primary : undefined}
+      tintColor={isActive ? theme.accent : undefined}
       onPress={() => {
         if (isActive) {
           addRouteWaypoint({ latitude, longitude });

--- a/src/routes/components/RouteListItem.tsx
+++ b/src/routes/components/RouteListItem.tsx
@@ -1,6 +1,7 @@
 import { type Route } from "@/database";
 import { toDistance } from "@/hooks/usePreferredUnits";
 import useTheme from "@/hooks/useTheme";
+import { createStyles } from "@/hooks/useStyles";
 import {
   getActiveRoute,
   handleDeleteRoute,
@@ -15,7 +16,6 @@ import {
   Alert,
   PlatformColor,
   Pressable,
-  StyleSheet,
   Text,
   View,
 } from "react-native";
@@ -128,6 +128,7 @@ type Props = {
 const RouteListItem = memo(
   function RouteListItem({ route, isNavigating }: Props) {
     const theme = useTheme();
+    const styles = useStyles();
     const dist = route.distance > 0 ? toDistance(route.distance) : null;
 
     return (
@@ -140,23 +141,15 @@ const RouteListItem = memo(
         ]}
       >
         <View style={styles.titleRow}>
-          <Text
-            style={[styles.title, { color: theme.textPrimary }]}
-            numberOfLines={1}
-          >
+          <Text style={styles.title} numberOfLines={1}>
             {routeDisplayName(route)}
           </Text>
           {isNavigating && (
-            <Text style={{ color: theme.primary, fontSize: 12 }}>▶</Text>
+            <Text style={{ color: theme.routes, fontSize: 12 }}>▶</Text>
           )}
         </View>
         {dist && (
-          <Text
-            style={[
-              styles.distance,
-              { color: theme.textSecondary },
-            ]}
-          >
+          <Text style={styles.distance}>
             {dist.value} {dist.abbr}
           </Text>
         )}
@@ -172,21 +165,18 @@ const RouteListItem = memo(
 
 export default RouteListItem;
 
-const styles = StyleSheet.create({
+const useStyles = createStyles((theme) => ({
   row: {
     paddingHorizontal: 16,
     paddingVertical: 12,
     justifyContent: "center",
     gap: 2,
   },
-  titleRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 6,
-  },
-  title: { fontSize: 16, fontWeight: "600", flexShrink: 1 },
+  titleRow: { flexDirection: "row", alignItems: "center", gap: 6 },
+  title: { fontSize: 16, fontWeight: "600", flexShrink: 1, color: theme.label },
   distance: {
     fontSize: 13,
     fontVariant: ["tabular-nums"],
+    color: theme.labelSecondary,
   },
-});
+}));

--- a/src/routes/components/RouteOverlay.tsx
+++ b/src/routes/components/RouteOverlay.tsx
@@ -104,7 +104,7 @@ function EditingOverlay() {
           <Layer
             id="route-edit-line-dash"
             type="line"
-            paint={{ "line-width": 3, "line-opacity": 1, "line-color": theme.primary, "line-dasharray": [2, 2] }}
+            paint={{ "line-width": 3, "line-opacity": 1, "line-color": theme.routes, "line-dasharray": [2, 2] }}
             layout={{ "line-cap": "round", "line-join": "round" }}
           />
         </GeoJSONSource>
@@ -116,7 +116,7 @@ function EditingOverlay() {
           id={`route-wp-${point.key}`}
           point={point}
           index={i}
-          color={theme.primary}
+          color={theme.routes}
           selected={i === activeIndex}
           draggable
           onPress={() => setActiveIndex(i === activeIndex ? null : i)}
@@ -191,7 +191,7 @@ function NavigatingOverlay() {
           <Layer
             id="route-completed-line"
             type="line"
-            paint={{ "line-width": 3, "line-opacity": 0.3, "line-color": theme.primary }}
+            paint={{ "line-width": 3, "line-opacity": 0.3, "line-color": theme.routes }}
             layout={{ "line-cap": "round", "line-join": "round" }}
           />
         </GeoJSONSource>
@@ -208,7 +208,7 @@ function NavigatingOverlay() {
           <Layer
             id="route-active-line"
             type="line"
-            paint={{ "line-width": 4, "line-opacity": 1, "line-color": theme.primary }}
+            paint={{ "line-width": 4, "line-opacity": 1, "line-color": theme.routes }}
             layout={{ "line-cap": "round", "line-join": "round" }}
           />
         </GeoJSONSource>
@@ -219,7 +219,7 @@ function NavigatingOverlay() {
           <Layer
             id="route-remaining-line"
             type="line"
-            paint={{ "line-width": 3, "line-opacity": 0.7, "line-color": theme.primary, "line-dasharray": [2, 2] }}
+            paint={{ "line-width": 3, "line-opacity": 0.7, "line-color": theme.routes, "line-dasharray": [2, 2] }}
             layout={{ "line-cap": "round", "line-join": "round" }}
           />
         </GeoJSONSource>
@@ -234,7 +234,7 @@ function NavigatingOverlay() {
             id={`route-wp-${point.key}`}
             point={point}
             index={i}
-            color={isCompleted ? theme.textTertiary : theme.primary}
+            color={isCompleted ? theme.labelTertiary : theme.routes}
             selected={isActive}
           />
         );

--- a/src/routes/components/WaypointBadge.tsx
+++ b/src/routes/components/WaypointBadge.tsx
@@ -17,9 +17,9 @@ export default function WaypointBadge({
   const theme = useTheme();
   const modifiers = [
     font({ size: 12, weight: "black" as const }),
-    foregroundStyle("white"),
+    foregroundStyle(theme.contrast),
     frame({ width: 24, height: 24 }),
-    background(theme.primary, shapes.circle()),  // inner fill
+    background(theme.accent, shapes.circle()),  // inner fill
   ];
 
   if (index === 0 || last) {
@@ -27,7 +27,7 @@ export default function WaypointBadge({
       <Image
         systemName={last ? "flag.pattern.checkered" : "flag.fill"}
         size={12}
-        color={"white"}
+        color={theme.contrast}
         modifiers={modifiers}
       />
     );

--- a/src/tracks/components/TrackDetail.tsx
+++ b/src/tracks/components/TrackDetail.tsx
@@ -116,12 +116,12 @@ export default function TrackDetail({ id }: { id: string }) {
                 data={chartData}
                 type="area"
                 showGrid={false}
-                areaStyle={{ color: theme.primary + "50" }}
-                lineStyle={{ color: theme.primary, width: 1.5 }}
+                areaStyle={{ color: theme.accent + "50" }}
+                lineStyle={{ color: theme.accent, width: 1.5 }}
                 modifiers={[
                   padding({ top: 10 }),
                   frame({ height: 70 }),
-                  background(theme.surfaceElevated),
+                  background(theme.surfaceFloating),
                   cornerRadius(12),
                 ]}
               />

--- a/src/tracks/components/TrackListItem.tsx
+++ b/src/tracks/components/TrackListItem.tsx
@@ -1,6 +1,6 @@
 import { type TrackWithStats } from "@/database";
 import { toDistance, toSpeed } from "@/hooks/usePreferredUnits";
-import useTheme from "@/hooks/useTheme";
+import { createStyles } from "@/hooks/useStyles";
 import {
   formatDate,
   formatDuration,
@@ -16,7 +16,6 @@ import {
   Alert,
   PlatformColor,
   Pressable,
-  StyleSheet,
   Text,
   View,
 } from "react-native";
@@ -66,13 +65,9 @@ type Props = {
   track: TrackWithStats;
 };
 
-// Memoized: `useTracks` returns a fresh array of fresh objects on every
-// fetch, so default shallow compare would never bail out — compare by id
-// plus the fields the row actually displays. All of those are cached on
-// the tracks row, so props only change on rename / end-of-track.
 const TrackListItem = memo(
   function TrackListItem({ track }: Props) {
-    const theme = useTheme();
+    const styles = useStyles();
     const dist = toDistance(track.distance);
     const avgSpd = track.avg_speed != null ? toSpeed(track.avg_speed) : null;
     const maxSpd = track.max_speed != null ? toSpeed(track.max_speed) : null;
@@ -83,44 +78,29 @@ const TrackListItem = memo(
         onLongPress={() => showTrackActions(track)}
         style={({ pressed }) => [
           styles.row,
-          // iOS adaptive press highlight. `systemFill` matches the default
-          // UITableView / SwiftUI List selection color and adjusts for
-          // light/dark automatically.
           pressed && { backgroundColor: PlatformColor("systemFill") },
         ]}
       >
         <View style={styles.topRow}>
-          <Text
-            style={[styles.title, { color: theme.textPrimary }]}
-            numberOfLines={1}
-          >
+          <Text style={styles.title} numberOfLines={1}>
             {trackDisplayName(track)}
           </Text>
-          <Text style={[styles.date, { color: theme.textSecondary }]}>
-            {formatDate(track.started_at)}
-          </Text>
+          <Text style={styles.date}>{formatDate(track.started_at)}</Text>
         </View>
 
         <View style={styles.statsRow}>
-          <StatItem
-            label="Distance"
-            value={`${dist.value} ${dist.abbr}`}
-            theme={theme}
-          />
+          <StatItem label="Distance" value={`${dist.value} ${dist.abbr}`} />
           <StatItem
             label="Duration"
             value={formatDuration(track.started_at, track.ended_at)}
-            theme={theme}
           />
           <StatItem
             label="Average"
             value={avgSpd ? `${avgSpd.value} ${avgSpd.abbr}` : "—"}
-            theme={theme}
           />
           <StatItem
             label="Max"
             value={maxSpd ? `${maxSpd.value} ${maxSpd.abbr}` : "—"}
-            theme={theme}
           />
         </View>
       </Pressable>
@@ -138,28 +118,17 @@ const TrackListItem = memo(
 
 export default TrackListItem;
 
-function StatItem({
-  label,
-  value,
-  theme,
-}: {
-  label: string;
-  value: string;
-  theme: ReturnType<typeof useTheme>;
-}) {
+function StatItem({ label, value }: { label: string; value: string }) {
+  const styles = useStyles();
   return (
     <View style={styles.stat}>
-      <Text style={[styles.statLabel, { color: theme.textSecondary }]}>
-        {label}
-      </Text>
-      <Text style={[styles.statValue, { color: theme.textPrimary }]}>
-        {value}
-      </Text>
+      <Text style={styles.statLabel}>{label}</Text>
+      <Text style={styles.statValue}>{value}</Text>
     </View>
   );
 }
 
-const styles = StyleSheet.create({
+const useStyles = createStyles((theme) => ({
   row: {
     height: ROW_HEIGHT,
     paddingHorizontal: 16,
@@ -173,17 +142,23 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     gap: 12,
   },
-  title: { fontSize: 16, fontWeight: "600", flexShrink: 1 },
-  date: { fontSize: 14 },
+  title: {
+    fontSize: 16,
+    fontWeight: "600",
+    flexShrink: 1,
+    color: theme.label,
+  },
+  date: { fontSize: 14, color: theme.labelSecondary },
   statsRow: {
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
   },
   stat: { flexDirection: "column" },
-  statLabel: { fontSize: 11, fontWeight: "600" },
+  statLabel: { fontSize: 11, fontWeight: "600", color: theme.labelSecondary },
   statValue: {
     fontWeight: "600",
     fontVariant: ["tabular-nums"],
+    color: theme.label,
   },
-});
+}));

--- a/src/tracks/components/TrackOverlay.tsx
+++ b/src/tracks/components/TrackOverlay.tsx
@@ -29,7 +29,7 @@ export default function TrackOverlay() {
 function ActiveTrackOverlay() {
   const theme = useTheme();
   const coordinates = useTrackRecordingPoints();
-  return <TrackLine id="active-track" coordinates={coordinates} color={theme.danger} />;
+  return <TrackLine id="active-track" coordinates={coordinates} color={theme.tracks} />;
 }
 
 function computeBounds(coords: Coordinate[]): LngLatBounds | null {
@@ -70,5 +70,5 @@ function SelectedTrackOverlay() {
 
   if (!selectedId) return null;
 
-  return <TrackLine id="selected-track" coordinates={coords} color={theme.primary} />;
+  return <TrackLine id="selected-track" coordinates={coords} color={theme.tracks} />;
 }

--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -14,7 +14,7 @@ export type ButtonProps = {
 
 export default function Button({ label, onPress, systemImage, role, variant = "default", color, style: containerStyle }: ButtonProps) {
   const theme = useTheme();
-  const tint = color ?? (role === "destructive" ? theme.danger : theme.primary);
+  const tint = color ?? (role === "destructive" ? theme.danger : theme.accent);
   const foreground = variant === "bordered" ? theme.surface : tint;
 
   return (
@@ -29,9 +29,7 @@ export default function Button({ label, onPress, systemImage, role, variant = "d
       ]}
     >
       {systemImage && <SymbolView name={systemImage} size={18} tintColor={foreground} />}
-      {label && <Text style={[styles.label, { color: foreground }]}>
-        {label}
-      </Text>}
+      {label && <Text style={[styles.label, { color: foreground }]}>{label}</Text>}
     </Pressable>
   );
 }

--- a/src/ui/OverlayView.tsx
+++ b/src/ui/OverlayView.tsx
@@ -1,8 +1,6 @@
-import {
-  GlassView,
-  isLiquidGlassAvailable,
-} from "expo-glass-effect";
-import { StyleSheet, useColorScheme, View, type StyleProp, type ViewStyle } from "react-native";
+import useTheme from "@/hooks/useTheme";
+import { GlassView, isLiquidGlassAvailable } from "expo-glass-effect";
+import { useColorScheme, View, type StyleProp, type ViewStyle } from "react-native";
 
 const liquidGlass = isLiquidGlassAvailable();
 
@@ -11,36 +9,26 @@ type OverlayViewProps = {
   children?: React.ReactNode;
 };
 
-export default function OverlayView({
-  style,
-  children,
-}: OverlayViewProps) {
-  const isDark = useColorScheme() === "dark";
+export default function OverlayView({ style, children }: OverlayViewProps) {
+  const theme = useTheme();
+  // useColorScheme() reflects the app-wide theme because _layout.tsx drives
+  // UIWindow.overrideUserInterfaceStyle from the chart theme.
+  const colorScheme = useColorScheme() === "dark" ? "dark" : "light";
 
   if (liquidGlass) {
     return (
-      <GlassView glassEffectStyle="regular" colorScheme={isDark ? "dark" : "light"} style={style} isInteractive>
+      <GlassView
+        glassEffectStyle="regular"
+        colorScheme={colorScheme}
+        style={style}
+        isInteractive
+      >
         {children}
       </GlassView>
     );
   }
 
   return (
-    <View style={[style, styles.fallback, isDark && styles.fallbackDark]}>
-      {children}
-    </View>
+    <View style={[{ backgroundColor: theme.surface }, style]}>{children}</View>
   );
 }
-
-const styles = StyleSheet.create({
-  fallback: {
-    backgroundColor: "white",
-    shadowColor: "#000",
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.25,
-    shadowRadius: 3.84,
-  },
-  fallbackDark: {
-    backgroundColor: "#1c1c1e",
-  },
-});

--- a/src/ui/RowSeparator.tsx
+++ b/src/ui/RowSeparator.tsx
@@ -1,4 +1,4 @@
-import useTheme from "@/hooks/useTheme";
+import { createStyles } from "@/hooks/useStyles";
 import { StyleSheet, View } from "react-native";
 
 type Props = {
@@ -7,24 +7,14 @@ type Props = {
   inset?: number;
 };
 
-/**
- * Hairline divider between rows in a `FlatList` via `ItemSeparatorComponent`,
- * or between any stacked elements. Uses `theme.border` for the color and
- * `StyleSheet.hairlineWidth` for the height so it renders as a single
- * device pixel regardless of scale.
- */
 export default function RowSeparator({ inset = 16 }: Props) {
-  const theme = useTheme();
-  return (
-    <View
-      style={[
-        styles.separator,
-        { backgroundColor: theme.border, marginLeft: inset },
-      ]}
-    />
-  );
+  const styles = useStyles();
+  return <View style={[styles.separator, { marginLeft: inset }]} />;
 }
 
-const styles = StyleSheet.create({
-  separator: { height: StyleSheet.hairlineWidth },
-});
+const useStyles = createStyles((theme) => ({
+  separator: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: theme.separator,
+  },
+}));

--- a/src/ui/SheetHeader.tsx
+++ b/src/ui/SheetHeader.tsx
@@ -20,12 +20,12 @@ export default function SheetHeader({ title, subtitle, onPressTitle }: Props) {
             <Text
               numberOfLines={1}
               onPress={onPressTitle}
-              style={{ color: theme.textPrimary, fontSize: 20, fontWeight: "700" }}
+              style={{ color: theme.label, fontSize: 20, fontWeight: "700" }}
             >
               {title}
             </Text>
             {subtitle != null && (
-              <Text numberOfLines={1} style={{ color: theme.textSecondary, fontSize: 15 }}>
+              <Text numberOfLines={1} style={{ color: theme.labelSecondary, fontSize: 15 }}>
                 {subtitle}
               </Text>
             )}

--- a/src/ui/Stat.tsx
+++ b/src/ui/Stat.tsx
@@ -15,12 +15,12 @@ export default function Stat({ label, value, unit }: Props) {
     <VStack spacing={2} modifiers={[
       frame({ maxWidth: Infinity }),
       padding({ all: 12 }),
-      background(theme.surfaceElevated),
+      background(theme.surfaceFloating),
       cornerRadius(12),
     ]}>
       <Text modifiers={[
         font({ size: 12, weight: "semibold" }),
-        foregroundStyle(theme.textSecondary),
+        foregroundStyle(theme.labelSecondary),
       ]}>
         {label}
       </Text>
@@ -29,13 +29,13 @@ export default function Stat({ label, value, unit }: Props) {
           <Text modifiers={[
             font({ size: 24, weight: "bold" }),
             monospacedDigit(),
-            foregroundStyle(theme.textPrimary),
+            foregroundStyle(theme.label),
           ]}>
             {value}
           </Text>
           <Text modifiers={[
             font({ size: 16, weight: "medium" }),
-            foregroundStyle(theme.textSecondary),
+            foregroundStyle(theme.labelSecondary),
           ]}>
             {unit}
           </Text>
@@ -44,7 +44,7 @@ export default function Stat({ label, value, unit }: Props) {
         <Text modifiers={[
           font({ size: 24, weight: "bold" }),
           monospacedDigit(),
-          foregroundStyle(theme.textPrimary),
+          foregroundStyle(theme.label),
         ]}>
           {value}
         </Text>

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -116,17 +116,18 @@ jest.mock("@expo/ui/swift-ui", () => {
   };
 });
 
-jest.mock("@expo/ui/swift-ui/modifiers", () => ({
-  environment: () => ({}),
-  frame: () => ({}),
-  glassEffect: () => ({}),
-  glassEffectId: () => ({}),
-  labelStyle: () => ({}),
-  contentTransition: () => ({}),
-  animation: () => ({}),
-  Animation: { default: "default" },
-  tint: () => ({}),
-}));
+// @expo/ui modifiers: every modifier is a function that returns an empty
+// descriptor. Proxy so adding a new modifier in app code doesn't require
+// updating this mock.
+jest.mock("@expo/ui/swift-ui/modifiers", () =>
+  new Proxy(
+    { Animation: { default: "default" } },
+    {
+      get: (target, prop) =>
+        prop in target ? (target as any)[prop] : () => ({}),
+    },
+  ),
+);
 
 // react-native-safe-area-context uses native modules; mock insets
 jest.mock("react-native-safe-area-context", () => ({

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,3 +1,10 @@
+// expo-platform-colors is a local native module; return fixed hex values for tests
+jest.mock("expo-platform-colors", () => ({
+  resolveSemanticColor: (_name: string, scheme: "light" | "dark") =>
+    scheme === "dark" ? "#000000" : "#FFFFFF",
+  setOverrideUserInterfaceStyle: jest.fn(),
+}));
+
 // react-native-reanimated uses native worklets; mock for tests
 jest.mock("react-native-reanimated", () => {
   const React = require("react");


### PR DESCRIPTION
- Add expo-platform-colors native module resolving UIKit semantic colors to hex and flipping UIWindow.overrideUserInterfaceStyle app-wide
- Rewrite useTheme around a single token table; materialize light/dark palettes once at module load
- Drive app scheme from the chart theme, flipping @expo/ui, GlassView, useColorScheme(), and presented sheets in one call
- Add createStyles factory hook; migrate StyleSheet+inline theme merges
- Rename textPrimary/Secondary/Tertiary → label/labelSecondary/Tertiary, primary → accent, surfaceElevated → surfaceFloating, border → separator
- Add domain tokens (tracks, routes, markers, ais, aton) and wire them at overlay call sites
- Add theme.contrast for foreground on saturated fills and map halos; replace hardcoded "white"/"#fff"
- Single-value custom tokens auto-derive dark variants via HSL adapt; theme.adapt(hex) exposes the same transform for user-picked colors