### PR TITLE
Add AIS Stream integration for internet-sourced vessel data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Copy this file to `.env.local` and fill in real values.
+# `.env.local` is gitignored.
+#
+# Variables prefixed with `EXPO_PUBLIC_` are inlined into the JS bundle at
+# build time by Metro's Babel plugin and read at runtime via
+# `process.env.EXPO_PUBLIC_<NAME>`. They are NOT secrets — anyone who can
+# download the IPA can extract them. Use them only for credentials that are
+# safe to ship to clients (rate-limited public API keys, feature flags, etc.).
+# Genuine secrets must live behind a backend proxy, not here.
+
+# Required for the AIS Stream integration. Get a key at https://aisstream.io/apikeys.
+# Treated as a public credential — aisstream.io's per-key rate limiting is the
+# protection model. See docs/specs/aisstream.md for the threat model.
+# Without this set, the AIS Stream toggle in the Connections sheet still
+# appears but the WebSocket stays disconnected.
+EXPO_PUBLIC_AISSTREAM_API_KEY=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,9 +32,16 @@ This project is built with [Expo](https://expo.dev/), a framework and platform f
 
 ```sh
 npm install
+cp .env.example .env.local # then fill in any keys you have (optional)
 npx expo prebuild          # generate native projects
 npx expo run:ios
 ```
+
+`.env.local` is gitignored and loaded automatically by Expo CLI. Variables
+prefixed with `EXPO_PUBLIC_` (e.g. `EXPO_PUBLIC_AISSTREAM_API_KEY`) are inlined
+into the JS bundle by Metro's Babel plugin and read at runtime via
+`process.env.EXPO_PUBLIC_*`. Missing keys degrade gracefully — features that
+need them stay disabled.
 
 ### Development Commands
 

--- a/app.json
+++ b/app.json
@@ -17,43 +17,64 @@
           "_signalk-ws._tcp",
           "_nmea-0183._tcp"
         ],
-        "UIBackgroundModes": ["location", "processing"],
+        "UIBackgroundModes": [
+          "location",
+          "processing"
+        ],
         "CFBundleDocumentTypes": [
           {
             "CFBundleTypeName": "MBTiles Chart Archive",
             "CFBundleTypeRole": "Viewer",
             "LSHandlerRank": "Alternate",
-            "LSItemContentTypes": ["io.openwaters.mbtiles"]
+            "LSItemContentTypes": [
+              "io.openwaters.mbtiles"
+            ]
           },
           {
             "CFBundleTypeName": "GPX Route",
             "CFBundleTypeRole": "Viewer",
             "LSHandlerRank": "Alternate",
-            "LSItemContentTypes": ["com.topografix.gpx"]
+            "LSItemContentTypes": [
+              "com.topografix.gpx"
+            ]
           },
           {
             "CFBundleTypeName": "ZIP Archive",
             "CFBundleTypeRole": "Viewer",
             "LSHandlerRank": "Alternate",
-            "LSItemContentTypes": ["public.zip-archive"]
+            "LSItemContentTypes": [
+              "public.zip-archive"
+            ]
           }
         ],
         "UTImportedTypeDeclarations": [
           {
             "UTTypeIdentifier": "io.openwaters.mbtiles",
             "UTTypeDescription": "MBTiles Chart Archive",
-            "UTTypeConformsTo": ["public.database", "public.data"],
+            "UTTypeConformsTo": [
+              "public.database",
+              "public.data"
+            ],
             "UTTypeTagSpecification": {
-              "public.filename-extension": ["mbtiles"]
+              "public.filename-extension": [
+                "mbtiles"
+              ]
             }
           },
           {
             "UTTypeIdentifier": "com.topografix.gpx",
             "UTTypeDescription": "GPX Route",
-            "UTTypeConformsTo": ["public.xml", "public.text"],
+            "UTTypeConformsTo": [
+              "public.xml",
+              "public.text"
+            ],
             "UTTypeTagSpecification": {
-              "public.filename-extension": ["gpx"],
-              "public.mime-type": ["application/gpx+xml"]
+              "public.filename-extension": [
+                "gpx"
+              ],
+              "public.mime-type": [
+                "application/gpx+xml"
+              ]
             }
           }
         ],
@@ -75,19 +96,30 @@
         "NSPrivacyAccessedAPITypes": [
           {
             "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults",
-            "NSPrivacyAccessedAPITypeReasons": ["CA92.1"]
+            "NSPrivacyAccessedAPITypeReasons": [
+              "CA92.1"
+            ]
           },
           {
             "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryFileTimestamp",
-            "NSPrivacyAccessedAPITypeReasons": ["0A2A.1", "3B52.1", "C617.1"]
+            "NSPrivacyAccessedAPITypeReasons": [
+              "0A2A.1",
+              "3B52.1",
+              "C617.1"
+            ]
           },
           {
             "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryDiskSpace",
-            "NSPrivacyAccessedAPITypeReasons": ["E174.1", "85F4.1"]
+            "NSPrivacyAccessedAPITypeReasons": [
+              "E174.1",
+              "85F4.1"
+            ]
           },
           {
             "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategorySystemBootTime",
-            "NSPrivacyAccessedAPITypeReasons": ["35F9.1"]
+            "NSPrivacyAccessedAPITypeReasons": [
+              "35F9.1"
+            ]
           }
         ]
       },

--- a/src/ais/components/VesselDetail.tsx
+++ b/src/ais/components/VesselDetail.tsx
@@ -2,7 +2,7 @@ import MarkerButton from "@/markers/components/MarkerButton";
 import RouteButton from "@/routes/components/RouteButton";
 import SheetBottomToolbar from "@/map/components/SheetBottomToolbar";
 import SheetHeader from "@/ui/SheetHeader";
-import { useAISVessel } from "@/ais/hooks/useAIS";
+import { type SourceFamily, useAISVessel, vesselPrimarySource } from "@/ais/hooks/useAIS";
 import { useNavigation, usePosition } from "@/navigation/hooks/useNavigation";
 import { toDepth, toDistance, toSpeed } from "@/hooks/usePreferredUnits";
 import { calculateCPA, formatBearing } from "@/geo";
@@ -46,6 +46,16 @@ function shipTypeName(code: number | undefined): string {
   if (code >= 70 && code <= 79) return "Cargo";
   if (code >= 80 && code <= 89) return "Tanker";
   return `Other (${code})`;
+}
+
+/** Human-readable label for a vessel's data source. */
+function sourceLabel(family: SourceFamily): string {
+  switch (family) {
+    case "signalk": return "Signal K";
+    case "nmea": return "NMEA";
+    case "aisstream": return "AIS Stream";
+    case "unknown": return "—";
+  }
 }
 
 /** Determine AIS class from MMSI pattern */
@@ -241,6 +251,9 @@ export default function VesselDetail({ id }: { id: string }) {
             </LabeledContent>
             <LabeledContent label="IMO">
               <Text modifiers={valueMods}>{imo ?? "—"}</Text>
+            </LabeledContent>
+            <LabeledContent label="Source">
+              <Text modifiers={valueMods}>{sourceLabel(vesselPrimarySource(vessel))}</Text>
             </LabeledContent>
           </Section>
         </Form>

--- a/src/ais/hooks/useAIS.ts
+++ b/src/ais/hooks/useAIS.ts
@@ -31,6 +31,19 @@ const AIS_FLUSH_INTERVAL = 1000; // ms
 let aisBuffer: Record<string, { paths: Record<string, DataPoint>; lastSeen: number }> = {};
 let aisFlushTimer: ReturnType<typeof setTimeout> | null = null;
 
+/**
+ * Newer-timestamp-wins merge gate. Returns true if `incoming` should replace
+ * `existing` at the same path. Used to merge updates from multiple sources
+ * (Signal K, NMEA, AIS Stream) without source-priority logic — whichever
+ * source has the freshest data for a given path is the one that wins.
+ */
+export function shouldAccept(
+  existing: DataPoint | undefined,
+  incoming: DataPoint,
+): boolean {
+  return existing === undefined || incoming.timestamp > existing.timestamp;
+}
+
 /** Flush buffered AIS updates to the store immediately */
 export function flushAIS() {
   aisFlushTimer = null;
@@ -41,9 +54,15 @@ export function flushAIS() {
 
   for (const [mmsi, update] of Object.entries(updates)) {
     const existing = aisState.vessels[mmsi];
+    const merged: Record<string, DataPoint> = { ...(existing?.data ?? {}) };
+    for (const [path, dp] of Object.entries(update.paths)) {
+      if (shouldAccept(merged[path], dp)) {
+        merged[path] = dp;
+      }
+    }
     aisState.vessels[mmsi] = {
       mmsi,
-      data: { ...(existing?.data ?? {}), ...update.paths },
+      data: merged,
       lastSeen: update.lastSeen,
     };
   }
@@ -54,19 +73,51 @@ function scheduleAISFlush() {
   aisFlushTimer = setTimeout(flushAIS, AIS_FLUSH_INTERVAL);
 }
 
-/** Create or update a vessel entry with new data paths (buffered) */
+/**
+ * Create or update a vessel entry with new data paths (buffered). Per-path
+ * updates are merged into the store via {@link shouldAccept} on flush — older
+ * values lose to newer ones regardless of source.
+ */
 export function updateAISVessel(
   mmsi: string,
   paths: Record<string, DataPoint>,
 ) {
   const existing = aisBuffer[mmsi];
   if (existing) {
-    Object.assign(existing.paths, paths);
+    for (const [path, dp] of Object.entries(paths)) {
+      if (shouldAccept(existing.paths[path], dp)) {
+        existing.paths[path] = dp;
+      }
+    }
     existing.lastSeen = Date.now();
   } else {
     aisBuffer[mmsi] = { paths: { ...paths }, lastSeen: Date.now() };
   }
   scheduleAISFlush();
+}
+
+/** Family label for a vessel's most-recent data source, shown in the detail sheet. */
+export type SourceFamily = "signalk" | "nmea" | "aisstream" | "unknown";
+
+/**
+ * Return the family of the source whose `DataPoint.timestamp` is most recent
+ * across all of the vessel's paths. Used purely for display — the merge rule
+ * is timestamp-only and doesn't consult source identity.
+ */
+export function vesselPrimarySource(vessel: AISVessel): SourceFamily {
+  let bestTimestamp = -Infinity;
+  let bestSource: string | undefined;
+  for (const dp of Object.values(vessel.data)) {
+    if (dp.timestamp > bestTimestamp) {
+      bestTimestamp = dp.timestamp;
+      bestSource = dp.source;
+    }
+  }
+  if (!bestSource) return "unknown";
+  if (bestSource.startsWith("signalk.")) return "signalk";
+  if (bestSource.startsWith("nmea.")) return "nmea";
+  if (bestSource === "aisstream") return "aisstream";
+  return "unknown";
 }
 
 /** Remove vessels not updated within maxAgeMs (default 9 minutes) */

--- a/src/aisstream/client.ts
+++ b/src/aisstream/client.ts
@@ -1,0 +1,294 @@
+import { updateAISVessel } from "@/ais/hooks/useAIS";
+import {
+  type AISStreamMessage,
+  decodeAISStreamMessage,
+} from "@/aisstream/messages";
+import { updateAtoN } from "@/aton/hooks/useAtoN";
+import log from "@/logger";
+
+const logger = log.extend("aisstream");
+
+export const AISSTREAM_URL = "wss://stream.aisstream.io/v0/stream";
+
+/**
+ * Default message types we subscribe to. Each maps to a code path in
+ * {@link decodeAISStreamMessage}:
+ *   PositionReport, StandardClassBPositionReport,
+ *   ExtendedClassBPositionReport, LongRangeAisBroadcastMessage,
+ *   StandardSearchAndRescueAircraftReport — vessel positions.
+ *   ShipStaticData, StaticDataReport — vessel identity/dimensions.
+ *   AidsToNavigationReport — buoys / lights / racons (routed to AtoN store).
+ */
+const DEFAULT_MESSAGE_TYPES = [
+  "PositionReport",
+  "StandardClassBPositionReport",
+  "ExtendedClassBPositionReport",
+  "ShipStaticData",
+  "StaticDataReport",
+  "AidsToNavigationReport",
+  "LongRangeAisBroadcastMessage",
+  "StandardSearchAndRescueAircraftReport",
+];
+
+/** Subscription bounding box: [[swLat, swLng], [neLat, neLng]] (aisstream order). */
+export type SubscriptionBox = [[number, number], [number, number]];
+
+export type AISStreamClientState = "disconnected" | "connecting" | "connected";
+
+export type AISStreamClientOptions = {
+  onStateChange?: (state: AISStreamClientState, error?: string) => void;
+};
+
+const MAX_BACKOFF = 30_000;
+const INITIAL_BACKOFF = 1_000;
+
+/**
+ * Minimum interval between subscription messages to AIS Stream.
+ * aisstream.io caps subscription updates at 1/sec.
+ */
+const SUBSCRIPTION_THROTTLE = 1_000;
+
+/** WebSocket client for aisstream.io. */
+export class AISStreamClient {
+  private ws: WebSocket | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private subscriptionTimer: ReturnType<typeof setTimeout> | null = null;
+  private lastSubscriptionAt = 0;
+  private pendingBoxes: SubscriptionBox[] | null = null;
+  private currentBoxes: SubscriptionBox[];
+  private backoff = INITIAL_BACKOFF;
+  private shouldReconnect = false;
+  private apiKey: string;
+  private options: AISStreamClientOptions;
+
+  state: AISStreamClientState = "disconnected";
+
+  constructor(
+    apiKey: string,
+    initialBoxes: SubscriptionBox[],
+    options: AISStreamClientOptions = {},
+  ) {
+    this.apiKey = apiKey;
+    this.currentBoxes = initialBoxes;
+    this.options = options;
+  }
+
+  /** Open the WebSocket and send the initial subscription. */
+  connect() {
+    this.shouldReconnect = true;
+    this.setState("connecting");
+
+    const ws = new WebSocket(AISSTREAM_URL);
+    // React Native's default `binaryType` is "blob", which arrives as an
+    // opaque Blob that can't be inspected synchronously. ArrayBuffer lets us
+    // decode the payload inline — aisstream uses permessage-deflate so frames
+    // can arrive as binary even though the payload is JSON text.
+    ws.binaryType = "arraybuffer";
+
+    ws.onopen = () => {
+      this.backoff = INITIAL_BACKOFF;
+      this.setState("connected");
+      // The subscription must arrive within 3 s or aisstream closes the socket.
+      this.sendSubscription(this.currentBoxes);
+    };
+
+    ws.onmessage = (event) => {
+      const raw: unknown = event.data;
+      let text: string | null = null;
+      if (typeof raw === "string") {
+        text = raw;
+      } else if (raw instanceof ArrayBuffer) {
+        try {
+          text = new TextDecoder("utf-8").decode(raw);
+        } catch {
+          text = null;
+        }
+      }
+
+      if (text === null) {
+        logger.warn(
+          `unhandled message payload type: ${typeof raw}` +
+            (raw && typeof raw === "object"
+              ? ` (constructor=${(raw as object).constructor?.name})`
+              : ""),
+        );
+        return;
+      }
+
+      // aisstream returns plain-text errors (not JSON) for things like a bad
+      // API key or an invalid bounding box. Surface those at warn level so
+      // they don't get lost as "malformed message" noise.
+      if (!text.startsWith("{")) {
+        logger.warn(`server message: ${text.slice(0, 200)}`);
+        return;
+      }
+      try {
+        const data = JSON.parse(text) as AISStreamMessage;
+        const decoded = decodeAISStreamMessage(data);
+        if (!decoded) return;
+        if (decoded.kind === "vessel") {
+          updateAISVessel(decoded.mmsi, decoded.paths);
+        } else {
+          updateAtoN(decoded.id, decoded.paths);
+        }
+      } catch (err) {
+        logger.debug("ignoring malformed message", err);
+      }
+    };
+
+    ws.onerror = () => {
+      // aisstream's error event carries no useful payload; details come on close.
+      this.setState("disconnected", "WebSocket error");
+    };
+
+    ws.onclose = (event) => {
+      this.ws = null;
+      const reason = event.reason || `code ${event.code}`;
+      this.setState("disconnected", reason);
+      if (this.shouldReconnect) {
+        this.scheduleReconnect();
+      }
+    };
+
+    this.ws = ws;
+  }
+
+  /**
+   * Update the subscription's bounding boxes. Throttled to one send per
+   * {@link SUBSCRIPTION_THROTTLE} ms — calls within the window coalesce, and
+   * the last requested boxes win.
+   */
+  updateSubscription(boxes: SubscriptionBox[]) {
+    this.currentBoxes = boxes;
+    if (this.state !== "connected") return; // queued — sent on next connect
+
+    const now = Date.now();
+    const elapsed = now - this.lastSubscriptionAt;
+    if (elapsed >= SUBSCRIPTION_THROTTLE) {
+      this.sendSubscription(boxes);
+      return;
+    }
+
+    // Coalesce within the throttle window.
+    this.pendingBoxes = boxes;
+    if (this.subscriptionTimer) return;
+    this.subscriptionTimer = setTimeout(() => {
+      this.subscriptionTimer = null;
+      const next = this.pendingBoxes;
+      this.pendingBoxes = null;
+      if (next && this.state === "connected") {
+        this.sendSubscription(next);
+      }
+    }, SUBSCRIPTION_THROTTLE - elapsed);
+  }
+
+  /** Stop reconnecting and close the socket. */
+  disconnect() {
+    this.shouldReconnect = false;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.subscriptionTimer) {
+      clearTimeout(this.subscriptionTimer);
+      this.subscriptionTimer = null;
+    }
+    this.pendingBoxes = null;
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+    this.setState("disconnected");
+  }
+
+  private sendSubscription(boxes: SubscriptionBox[]) {
+    if (!this.ws || this.ws.readyState !== 1) return;
+    const message = {
+      APIKey: this.apiKey,
+      BoundingBoxes: boxes,
+      FilterMessageTypes: DEFAULT_MESSAGE_TYPES,
+    };
+    try {
+      this.ws.send(JSON.stringify(message));
+      this.lastSubscriptionAt = Date.now();
+    } catch (err) {
+      logger.warn("failed to send subscription", err);
+    }
+  }
+
+  private setState(state: AISStreamClientState, error?: string) {
+    if (this.state === state && !error) return;
+    this.state = state;
+    this.options.onStateChange?.(state, error);
+  }
+
+  private scheduleReconnect() {
+    if (this.reconnectTimer) return;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect();
+    }, this.backoff);
+    this.backoff = Math.min(this.backoff * 2, MAX_BACKOFF);
+  }
+}
+
+/**
+ * Split a `[west, south, east, north]` MapLibre bounds tuple into one or two
+ * AIS Stream bounding boxes, handling antimeridian crossing. AIS Stream wants
+ * `[[swLat, swLng], [neLat, neLng]]` (lat-first, opposite of MapLibre).
+ */
+export function boundsToSubscription(
+  bounds: [number, number, number, number],
+): SubscriptionBox[] {
+  const [west, south, east, north] = bounds;
+  const swLat = Math.max(-90, south);
+  const neLat = Math.min(90, north);
+  if (west <= east) {
+    return [
+      [
+        [swLat, west],
+        [neLat, east],
+      ],
+    ];
+  }
+  // Viewport crosses the antimeridian: split into two halves.
+  return [
+    [
+      [swLat, west],
+      [neLat, 180],
+    ],
+    [
+      [swLat, -180],
+      [neLat, east],
+    ],
+  ];
+}
+
+/**
+ * Pad a `[west, south, east, north]` bounds by `factor` of its own span on
+ * each side. e.g. factor=0.5 → subscription covers 1.5× viewport width.
+ * Latitude is clamped to ±90; longitude wraps via antimeridian split in
+ * {@link boundsToSubscription}.
+ */
+export function padBounds(
+  bounds: [number, number, number, number],
+  factor: number,
+): [number, number, number, number] {
+  const [west, south, east, north] = bounds;
+  const lonSpan = east >= west ? east - west : east + 360 - west;
+  const latSpan = north - south;
+  const lonPad = lonSpan * factor;
+  const latPad = latSpan * factor;
+  // Wrap longitude into [-180, 180].
+  const wrapLon = (x: number) => {
+    let v = ((((x + 180) % 360) + 360) % 360) - 180;
+    if (v === -180) v = 180;
+    return v;
+  };
+  return [
+    wrapLon(west - lonPad),
+    Math.max(-90, south - latPad),
+    wrapLon(east + lonPad),
+    Math.min(90, north + latPad),
+  ];
+}

--- a/src/aisstream/hooks/useAISStream.ts
+++ b/src/aisstream/hooks/useAISStream.ts
@@ -1,0 +1,38 @@
+import { persistProxy } from "@/persistProxy";
+import { proxy, useSnapshot } from "valtio";
+
+export type AISStreamStatus = "disconnected" | "connecting" | "connected";
+
+interface State {
+  /** User-facing toggle. Defaults on; users can opt out from the Connections sheet. */
+  enabled: boolean;
+  status: AISStreamStatus;
+  error: string | undefined;
+}
+
+export const aisStreamState = proxy<State>({
+  enabled: true,
+  status: "disconnected",
+  error: undefined,
+});
+
+persistProxy<State, Pick<State, "enabled">>(aisStreamState, {
+  name: "aisstream",
+  partialize: (s) => ({ enabled: s.enabled }),
+});
+
+export function useAISStream() {
+  return useSnapshot(aisStreamState);
+}
+
+export function setAISStreamEnabled(enabled: boolean) {
+  aisStreamState.enabled = enabled;
+}
+
+export function setAISStreamStatus(
+  status: AISStreamStatus,
+  error?: string,
+) {
+  aisStreamState.status = status;
+  aisStreamState.error = error;
+}

--- a/src/aisstream/index.ts
+++ b/src/aisstream/index.ts
@@ -1,0 +1,129 @@
+import {
+  AISStreamClient,
+  type SubscriptionBox,
+  boundsToSubscription,
+  padBounds,
+} from "@/aisstream/client";
+import {
+  aisStreamState,
+  setAISStreamStatus,
+} from "@/aisstream/hooks/useAISStream";
+import log from "@/logger";
+import { cameraViewState } from "@/map/hooks/useCameraView";
+import {
+  AppState,
+  type AppStateStatus,
+  type NativeEventSubscription,
+} from "react-native";
+import { subscribeKey } from "valtio/utils";
+
+const logger = log.extend("aisstream");
+
+/** Inflate the subscription window relative to the viewport. */
+const BOUNDS_PAD_FACTOR = 0.5;
+
+/** Initial subscription when no bounds are available yet. Replaced as soon as the camera settles. */
+const WORLD_BOUNDS: [number, number, number, number] = [-179, -89, 179, 89];
+
+let client: AISStreamClient | null = null;
+let unsubscribers: Array<() => void> = [];
+let appStateActive = AppState.currentState === "active";
+
+function getApiKey(): string | undefined {
+  // Metro's Babel plugin inlines references to `process.env.EXPO_PUBLIC_*` at
+  // build time, so this read happens against the bundled value — no manifest
+  // or Constants indirection.
+  const key = process.env.EXPO_PUBLIC_AISSTREAM_API_KEY;
+  return typeof key === "string" && key.length > 0 ? key : undefined;
+}
+
+function currentSubscription(): SubscriptionBox[] {
+  const bounds = cameraViewState.bounds ?? WORLD_BOUNDS;
+  return boundsToSubscription(padBounds(bounds, BOUNDS_PAD_FACTOR));
+}
+
+function connect() {
+  if (client) return;
+  const apiKey = getApiKey();
+  if (!apiKey) {
+    logger.warn(
+      "no API key configured; staying disconnected. " +
+        "Set EXPO_PUBLIC_AISSTREAM_API_KEY in .env.local and restart Metro with `--clear`.",
+    );
+    setAISStreamStatus("disconnected", "Missing API key");
+    return;
+  }
+  logger.info("connecting");
+  client = new AISStreamClient(apiKey, currentSubscription(), {
+    onStateChange: (state, error) => {
+      setAISStreamStatus(state, error);
+    },
+  });
+  client.connect();
+}
+
+function disconnect() {
+  if (!client) return;
+  logger.info("disconnecting");
+  client.disconnect();
+  client = null;
+  setAISStreamStatus("disconnected");
+}
+
+function reconcile() {
+  const wantConnection = aisStreamState.enabled && appStateActive;
+  if (wantConnection) {
+    connect();
+  } else {
+    disconnect();
+  }
+}
+
+function handleAppStateChange(state: AppStateStatus) {
+  appStateActive = state === "active";
+  reconcile();
+}
+
+/**
+ * Bring AIS Stream online if it's enabled. Idempotent — calling `activate`
+ * again with no state change is a no-op. Subscribes to:
+ *   - `aisStreamState.enabled` so user toggles reconnect/tear-down
+ *   - `cameraViewState.bounds` so the subscription tracks the viewport
+ *   - `AppState` to pause when backgrounded
+ */
+export function activate() {
+  if (unsubscribers.length > 0) return; // already activated
+
+  logger.info(
+    `activating (enabled=${aisStreamState.enabled}, appState=${AppState.currentState}, hasKey=${!!getApiKey()})`,
+  );
+
+  // Enable/disable toggle
+  unsubscribers.push(
+    subscribeKey(aisStreamState, "enabled", () => reconcile()),
+  );
+
+  // Bounds tracking — the client's own throttle (1/sec) handles aisstream's cap.
+  unsubscribers.push(
+    subscribeKey(cameraViewState, "bounds", () => {
+      if (!client) return;
+      client.updateSubscription(currentSubscription());
+    }),
+  );
+
+  // AppState — tear down when backgrounded.
+  const appStateSub: NativeEventSubscription = AppState.addEventListener(
+    "change",
+    handleAppStateChange,
+  );
+  unsubscribers.push(() => appStateSub.remove());
+
+  reconcile();
+}
+
+/** Tear down the WebSocket and all subscriptions. */
+export function deactivate() {
+  for (const unsub of unsubscribers) unsub();
+  unsubscribers = [];
+  disconnect();
+}

--- a/src/aisstream/messages.ts
+++ b/src/aisstream/messages.ts
@@ -1,0 +1,386 @@
+import type { DataPoint } from "@/instruments/hooks/useInstruments";
+
+/**
+ * AIS Stream WebSocket message envelope. See
+ * https://aisstream.io/documentation for the full taxonomy.
+ *
+ * Only the fields we actually consume are typed — unrecognized fields are
+ * passed through silently.
+ */
+export type AISStreamMessage = {
+  MessageType: string;
+  MetaData?: {
+    MMSI?: number;
+    ShipName?: string;
+    latitude?: number;
+    longitude?: number;
+    /** "2022-12-29 18:22:32.318353 +0000 UTC" or RFC 3339 */
+    time_utc?: string;
+  };
+  Message?: Record<string, unknown>;
+};
+
+/** Source tag attached to every DataPoint we derive from AIS Stream. */
+export const AISSTREAM_SOURCE = "aisstream";
+
+/** Sentinel from the AIS spec: 511° means "heading not available". */
+const HEADING_NOT_AVAILABLE = 511;
+
+/** Knots → m/s. */
+const KNOTS_TO_MPS = 0.514444;
+
+/** Degrees → radians. */
+const DEG_TO_RAD = Math.PI / 180;
+
+/** AIS Stream `time_utc` parser with a `Date.now()` fallback. */
+function parseTimestamp(raw: string | undefined): number {
+  if (!raw) return Date.now();
+  // Strip the trailing "UTC" — JS Date can't parse that suffix but the
+  // "+0000" before it is unambiguous on its own.
+  const cleaned = raw.replace(/\s*UTC\s*$/, "").trim();
+  const t = Date.parse(cleaned);
+  return Number.isNaN(t) ? Date.now() : t;
+}
+
+/** Trim trailing AIS `@` padding and whitespace from a 6-bit packed string. */
+function trimAis(s: string | undefined): string | undefined {
+  if (s == null) return undefined;
+  const trimmed = s.replace(/@+$/, "").trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+type RawPosition = {
+  Latitude?: number;
+  Longitude?: number;
+  Cog?: number;
+  Sog?: number;
+  TrueHeading?: number;
+  NavigationalStatus?: number;
+  /** AIS sentinel `-128` = "no info"; otherwise deg/min (sign = direction). */
+  RateOfTurn?: number;
+};
+
+type RawEta = {
+  Day?: number;
+  Hour?: number;
+  Minute?: number;
+  Month?: number;
+};
+
+type RawStaticData = {
+  Type?: number;
+  CallSign?: string;
+  Destination?: string;
+  ImoNumber?: number;
+  MaximumStaticDraught?: number;
+  Dimension?: { A?: number; B?: number; C?: number; D?: number };
+  Eta?: RawEta;
+  /** Some payloads (Type 24B) call it ShipType instead of Type. */
+  ShipType?: number;
+};
+
+type RawStaticDataReport = {
+  /**
+   * AIS Stream encodes the part-number bit as a boolean: `false` = Part A,
+   * `true` = Part B. (See aisstream/ais-message-models type-definition.yaml.)
+   */
+  PartNumber?: boolean;
+  ReportA?: { Name?: string };
+  ReportB?: RawStaticData;
+};
+
+type RawAidsToNavigationReport = {
+  Type?: number;
+  Name?: string;
+  NameExtension?: string;
+  Longitude?: number;
+  Latitude?: number;
+  OffPosition?: boolean;
+  VirtualAtoN?: boolean;
+  Dimension?: { A?: number; B?: number; C?: number; D?: number };
+};
+
+/** AIS RateOfTurn sentinel — "not available". */
+const ROT_NOT_AVAILABLE = -128;
+
+/** AIS ETA: format MM-DDTHH:MM (no year — AIS doesn't broadcast one). */
+function formatEta(eta: RawEta): string | undefined {
+  const { Month, Day, Hour, Minute } = eta;
+  // AIS uses 0 for "not available" in each field.
+  if (!Month || !Day) return undefined;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(Month)}-${pad(Day)}T${pad(Hour ?? 0)}:${pad(Minute ?? 0)}`;
+}
+
+/**
+ * Result of decoding one AIS Stream message. Discriminated on `kind` so the
+ * client can route vessel paths to {@link updateAISVessel} and AtoN paths to
+ * {@link updateAtoN}.
+ */
+export type AISStreamDecodeResult =
+  | { kind: "vessel"; mmsi: string; paths: Record<string, DataPoint> }
+  | { kind: "aton"; id: string; paths: Record<string, DataPoint> }
+  | null;
+
+function dp(value: DataPoint["value"], timestamp: number): DataPoint {
+  return { value, timestamp, source: AISSTREAM_SOURCE };
+}
+
+function decodePositionPaths(
+  pos: RawPosition,
+  timestamp: number,
+): Record<string, DataPoint> {
+  const paths: Record<string, DataPoint> = {};
+  if (typeof pos.Latitude === "number" && typeof pos.Longitude === "number") {
+    paths["navigation.position"] = dp(
+      { latitude: pos.Latitude, longitude: pos.Longitude },
+      timestamp,
+    );
+  }
+  if (typeof pos.Cog === "number") {
+    paths["navigation.courseOverGroundTrue"] = dp(pos.Cog * DEG_TO_RAD, timestamp);
+  }
+  if (typeof pos.Sog === "number") {
+    paths["navigation.speedOverGround"] = dp(pos.Sog * KNOTS_TO_MPS, timestamp);
+  }
+  if (
+    typeof pos.TrueHeading === "number" &&
+    pos.TrueHeading !== HEADING_NOT_AVAILABLE
+  ) {
+    paths["navigation.headingTrue"] = dp(pos.TrueHeading * DEG_TO_RAD, timestamp);
+  }
+  if (typeof pos.NavigationalStatus === "number") {
+    paths["navigation.state"] = dp(pos.NavigationalStatus, timestamp);
+  }
+  if (
+    typeof pos.RateOfTurn === "number" &&
+    pos.RateOfTurn !== ROT_NOT_AVAILABLE
+  ) {
+    // AIS RateOfTurn is deg/min; Signal K convention is rad/s. Convert.
+    const rotRadPerSec = (pos.RateOfTurn * DEG_TO_RAD) / 60;
+    paths["navigation.rateOfTurn"] = dp(rotRadPerSec, timestamp);
+  }
+  return paths;
+}
+
+function decodeStaticDataPaths(
+  data: RawStaticData,
+  timestamp: number,
+): Record<string, DataPoint> {
+  const paths: Record<string, DataPoint> = {};
+  if (typeof data.Type === "number") {
+    paths["design.aisShipType"] = dp(data.Type, timestamp);
+  }
+  const callSign = trimAis(data.CallSign);
+  if (callSign) {
+    paths["communication.callsignVhf"] = dp(callSign, timestamp);
+  }
+  const destination = trimAis(data.Destination);
+  if (destination) {
+    paths["navigation.destination"] = dp(destination, timestamp);
+  }
+  if (typeof data.ImoNumber === "number" && data.ImoNumber > 0) {
+    paths["registrations.imo"] = dp(String(data.ImoNumber), timestamp);
+  }
+  if (typeof data.MaximumStaticDraught === "number" && data.MaximumStaticDraught > 0) {
+    paths["design.draft"] = dp(data.MaximumStaticDraught, timestamp);
+  }
+  const dim = data.Dimension;
+  if (dim) {
+    const a = typeof dim.A === "number" ? dim.A : 0;
+    const b = typeof dim.B === "number" ? dim.B : 0;
+    const c = typeof dim.C === "number" ? dim.C : 0;
+    const d = typeof dim.D === "number" ? dim.D : 0;
+    const length = a + b;
+    const beam = c + d;
+    if (length > 0) paths["design.length"] = dp(length, timestamp);
+    if (beam > 0) paths["design.beam"] = dp(beam, timestamp);
+  }
+  if (data.Eta) {
+    const eta = formatEta(data.Eta);
+    if (eta) paths["navigation.eta"] = dp(eta, timestamp);
+  }
+  // Some payloads use ShipType in place of Type.
+  if (typeof data.ShipType === "number" && !paths["design.aisShipType"]) {
+    paths["design.aisShipType"] = dp(data.ShipType, timestamp);
+  }
+  return paths;
+}
+
+/**
+ * Type 24 — Class B static data, delivered as two halves (PartNumber 0 / 1).
+ * Part A is just the vessel name; Part B carries call sign, ship type, and
+ * dimensions. Each part arrives in its own AIS Stream message.
+ */
+function decodeStaticDataReport(
+  report: RawStaticDataReport,
+  timestamp: number,
+): Record<string, DataPoint> {
+  const paths: Record<string, DataPoint> = {};
+  // `PartNumber` is a boolean: false = Part A (name only), true = Part B
+  // (identity + dimensions). The two parts arrive in separate messages.
+  if (report.PartNumber === false && report.ReportA) {
+    const name = trimAis(report.ReportA.Name);
+    if (name) paths["name"] = dp(name, timestamp);
+  } else if (report.PartNumber === true && report.ReportB) {
+    Object.assign(paths, decodeStaticDataPaths(report.ReportB, timestamp));
+  }
+  return paths;
+}
+
+/** Type 21 — Aid to Navigation report. Routed to the AtoN store, not vessels. */
+function decodeAtoNPaths(
+  report: RawAidsToNavigationReport,
+  timestamp: number,
+): Record<string, DataPoint> {
+  const paths: Record<string, DataPoint> = {};
+  if (
+    typeof report.Latitude === "number" &&
+    typeof report.Longitude === "number"
+  ) {
+    paths["navigation.position"] = dp(
+      { latitude: report.Latitude, longitude: report.Longitude },
+      timestamp,
+    );
+  }
+  if (typeof report.Type === "number") {
+    paths["atonType"] = dp(report.Type, timestamp);
+  }
+  // AIS Type 21 names are 14 chars + an optional NameExtension. Concatenate
+  // both before trimming so the trailing-`@` pad on the base name doesn't
+  // chop the extension off.
+  const rawName = `${report.Name ?? ""}${report.NameExtension ?? ""}`;
+  const name = trimAis(rawName);
+  if (name) paths["name"] = dp(name, timestamp);
+  // DataPoint.value doesn't include boolean today; encode as 1/0 — the AtoN
+  // detail sheet's `getBoolean()` already accepts that shape alongside true/false.
+  if (typeof report.OffPosition === "boolean") {
+    paths["offPosition"] = dp(report.OffPosition ? 1 : 0, timestamp);
+  }
+  if (typeof report.VirtualAtoN === "boolean") {
+    paths["virtual"] = dp(report.VirtualAtoN ? 1 : 0, timestamp);
+  }
+  return paths;
+}
+
+/** Decode a single AIS Stream message into a per-path DataPoint map. */
+export function decodeAISStreamMessage(
+  msg: AISStreamMessage,
+): AISStreamDecodeResult {
+  const meta = msg.MetaData;
+  if (!meta || typeof meta.MMSI !== "number") return null;
+  const mmsi = String(meta.MMSI);
+  const timestamp = parseTimestamp(meta.time_utc);
+
+  const inner = msg.Message ?? {};
+  const atonReport = inner["AidsToNavigationReport"] as
+    | RawAidsToNavigationReport
+    | undefined;
+
+  // AtoN reports are routed to the AtoN store, not the vessel store.
+  if (atonReport) {
+    const atonPaths = decodeAtoNPaths(atonReport, timestamp);
+    // Position fallback from MetaData (same logic as vessels below). Done
+    // before adding the synthetic `mmsi` path so the emptiness check below
+    // reflects whether the message actually carried any decodable AtoN data.
+    if (
+      !atonPaths["navigation.position"] &&
+      typeof meta.latitude === "number" &&
+      typeof meta.longitude === "number" &&
+      (meta.latitude !== 0 || meta.longitude !== 0)
+    ) {
+      atonPaths["navigation.position"] = dp(
+        { latitude: meta.latitude, longitude: meta.longitude },
+        timestamp,
+      );
+    }
+    if (Object.keys(atonPaths).length === 0) return null;
+    atonPaths["mmsi"] = dp(mmsi, timestamp);
+    return { kind: "aton", id: mmsi, paths: atonPaths };
+  }
+
+  const paths: Record<string, DataPoint> = {};
+
+  // Ship name lives on MetaData on every message type — opportunistic identity.
+  const name = trimAis(meta.ShipName);
+  if (name) {
+    paths["name"] = dp(name, timestamp);
+  }
+
+  const positionReport = inner["PositionReport"] as RawPosition | undefined;
+  const classBPosition = inner["StandardClassBPositionReport"] as
+    | RawPosition
+    | undefined;
+  const extendedClassB = inner["ExtendedClassBPositionReport"] as
+    | (RawPosition & RawStaticData & { Name?: string })
+    | undefined;
+  const staticData = inner["ShipStaticData"] as RawStaticData | undefined;
+  const staticDataReport = inner["StaticDataReport"] as
+    | RawStaticDataReport
+    | undefined;
+  const longRange = inner["LongRangeAisBroadcastMessage"] as
+    | RawPosition
+    | undefined;
+  const sarAircraft = inner["StandardSearchAndRescueAircraftReport"] as
+    | RawPosition
+    | undefined;
+
+  if (positionReport) {
+    Object.assign(paths, decodePositionPaths(positionReport, timestamp));
+  }
+  if (classBPosition) {
+    Object.assign(paths, decodePositionPaths(classBPosition, timestamp));
+  }
+  if (extendedClassB) {
+    Object.assign(paths, decodePositionPaths(extendedClassB, timestamp));
+    Object.assign(paths, decodeStaticDataPaths(extendedClassB, timestamp));
+    const extName = trimAis(extendedClassB.Name);
+    if (extName && !paths["name"]) {
+      paths["name"] = dp(extName, timestamp);
+    }
+  }
+  if (staticData) {
+    Object.assign(paths, decodeStaticDataPaths(staticData, timestamp));
+  }
+  if (staticDataReport) {
+    Object.assign(paths, decodeStaticDataReport(staticDataReport, timestamp));
+  }
+  if (longRange) {
+    // Type 27: low-resolution Class A position, used over satellite. Same
+    // position fields as PositionReport, plus a `ShipType` field — the one
+    // position-bearing message that also carries ship type, so it's worth
+    // pulling identity from too.
+    Object.assign(paths, decodePositionPaths(longRange, timestamp));
+    const lrShipType = (longRange as RawPosition & { ShipType?: number })
+      .ShipType;
+    if (typeof lrShipType === "number" && !paths["design.aisShipType"]) {
+      paths["design.aisShipType"] = dp(lrShipType, timestamp);
+    }
+  }
+  if (sarAircraft) {
+    // Type 9: SAR aircraft. Same paths as a vessel position report — by MMSI
+    // (typically a 111... prefix). Altitude isn't surfaced by the detail
+    // sheet today, so we don't bother routing it through.
+    Object.assign(paths, decodePositionPaths(sarAircraft, timestamp));
+  }
+
+  // Fall back to MetaData position when no inner message contributed one.
+  // Mainly relevant for ShipStaticData / StaticDataReport: the inner body
+  // has no position, but MetaData carries where the broadcast was last
+  // received from. Without this, a static-only vessel never plots.
+  if (
+    !paths["navigation.position"] &&
+    typeof meta.latitude === "number" &&
+    typeof meta.longitude === "number" &&
+    // Filter out the (0, 0) "null island" sentinel some samples use.
+    (meta.latitude !== 0 || meta.longitude !== 0)
+  ) {
+    paths["navigation.position"] = dp(
+      { latitude: meta.latitude, longitude: meta.longitude },
+      timestamp,
+    );
+  }
+
+  if (Object.keys(paths).length === 0) return null;
+  return { kind: "vessel", mmsi, paths };
+}

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -1,3 +1,4 @@
+import { activate as activateAISStream, deactivate as deactivateAISStream } from "@/aisstream";
 import { cancelAllDownloads } from "@/charts/download";
 import { useActiveTheme } from "@/charts/hooks/useCharts";
 import DisclaimerScreen from "@/disclaimer/components/DisclaimerScreen";
@@ -48,6 +49,12 @@ function RootLayout() {
   useEffect(() => {
     connectAll();
     return () => disconnectAll();
+  }, []);
+
+  // Bring up the AIS Stream cloud feed if enabled
+  useEffect(() => {
+    activateAISStream();
+    return () => deactivateAISStream();
   }, []);
 
   // Handle GPX/ZIP files opened via iOS share sheet or "Open in"

--- a/src/app/connections.tsx
+++ b/src/app/connections.tsx
@@ -1,3 +1,7 @@
+import {
+  setAISStreamEnabled,
+  useAISStream,
+} from "@/aisstream/hooks/useAISStream";
 import useTheme from "@/hooks/useTheme";
 import {
   type DiscoveredService,
@@ -11,7 +15,7 @@ import {
   useConnections,
 } from "@/instruments/hooks/useConnections";
 import SheetView from "@/ui/SheetView";
-import { Button, Host, HStack, Image, List, Picker, ProgressView, Section, Spacer, Text, TextField, VStack } from "@expo/ui/swift-ui";
+import { Button, Host, HStack, Image, List, Picker, ProgressView, Section, Spacer, Text, TextField, Toggle, VStack } from "@expo/ui/swift-ui";
 import { autocorrectionDisabled, buttonStyle, clipShape, font, foregroundStyle, frame, keyboardType, labelStyle, onTapGesture, pickerStyle, progressViewStyle, tag, textInputAutocapitalization, tint } from "@expo/ui/swift-ui/modifiers";
 import { router, Stack } from "expo-router";
 import { useCallback, useEffect, useState } from "react";
@@ -36,6 +40,7 @@ function StatusIcon({ status, hasError }: { status: ConnectionStatus; hasError: 
 
 export default function Connections() {
   const { connections } = useConnections();
+  const aisStream = useAISStream();
   const [discovered, setDiscovered] = useState<DiscoveredService[]>([]);
   const [addType, setAddType] = useState<"signalk" | "nmea">("signalk");
   const [signalKUrl, setSignalKUrl] = useState("");
@@ -121,6 +126,35 @@ export default function Connections() {
 
       <Host style={{ flex: 1 }}>
         <List>
+          <Section
+            title="AIS Stream"
+            footer={
+              <Text>
+                Streams worldwide AIS vessel positions over the internet from aisstream.io. Shows vessels beyond your AIS receiver's range, or anywhere when no receiver is connected. Turn off to save cellular data.
+              </Text>
+            }
+          >
+            <HStack spacing={12}>
+              <VStack alignment="leading" spacing={2}>
+                <Text modifiers={[foregroundStyle("primary"), font({ weight: "semibold" })]}>
+                  Internet AIS
+                </Text>
+                <Text modifiers={[foregroundStyle("secondary"), font({ size: 12 })]}>
+                  aisstream.io
+                </Text>
+              </VStack>
+              <Spacer />
+              <StatusIcon
+                status={aisStream.status}
+                hasError={!!aisStream.error}
+              />
+              <Toggle
+                isOn={aisStream.enabled}
+                onIsOnChange={setAISStreamEnabled}
+              />
+            </HStack>
+          </Section>
+
           {connections.length > 0 ? (
             <Section title="Connections">
               {connections.map((conn) => (

--- a/tests/ais/hooks/useAIS.test.ts
+++ b/tests/ais/hooks/useAIS.test.ts
@@ -3,7 +3,9 @@ import {
   clearAIS,
   flushAIS,
   pruneStaleVessels,
+  shouldAccept,
   updateAISVessel,
+  vesselPrimarySource,
 } from "@/ais/hooks/useAIS";
 
 beforeEach(() => {
@@ -151,6 +153,215 @@ describe("useAIS", () => {
       flushAIS();
       clearAIS();
       expect(aisState.vessels).toEqual({});
+    });
+  });
+
+  describe("shouldAccept", () => {
+    it("accepts when nothing exists yet", () => {
+      expect(
+        shouldAccept(undefined, { value: 1, timestamp: 100, source: "x" }),
+      ).toBe(true);
+    });
+
+    it("accepts strictly-newer timestamps", () => {
+      expect(
+        shouldAccept(
+          { value: 1, timestamp: 100, source: "a" },
+          { value: 2, timestamp: 101, source: "b" },
+        ),
+      ).toBe(true);
+    });
+
+    it("drops older timestamps", () => {
+      expect(
+        shouldAccept(
+          { value: 1, timestamp: 100, source: "a" },
+          { value: 2, timestamp: 99, source: "b" },
+        ),
+      ).toBe(false);
+    });
+
+    it("drops equal timestamps", () => {
+      // Same broadcast received via two pipes — first writer wins, no overwrite.
+      expect(
+        shouldAccept(
+          { value: 1, timestamp: 100, source: "a" },
+          { value: 2, timestamp: 100, source: "b" },
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("merge gate in updateAISVessel", () => {
+    it("drops older-timestamp updates for an existing path", () => {
+      updateAISVessel("211234567", {
+        "navigation.position": {
+          value: { latitude: 47.6, longitude: -122.3 },
+          timestamp: 2000,
+          source: "signalk.local",
+        },
+      });
+      flushAIS();
+      // Older timestamp from another source — should not overwrite.
+      updateAISVessel("211234567", {
+        "navigation.position": {
+          value: { latitude: 0, longitude: 0 },
+          timestamp: 1000,
+          source: "aisstream",
+        },
+      });
+      flushAIS();
+
+      const dp = aisState.vessels["211234567"].data["navigation.position"];
+      expect(dp?.value).toEqual({ latitude: 47.6, longitude: -122.3 });
+      expect(dp?.source).toBe("signalk.local");
+    });
+
+    it("accepts newer-timestamp updates from any source", () => {
+      updateAISVessel("211234567", {
+        "navigation.position": {
+          value: { latitude: 47.6, longitude: -122.3 },
+          timestamp: 1000,
+          source: "aisstream",
+        },
+      });
+      flushAIS();
+      updateAISVessel("211234567", {
+        "navigation.position": {
+          value: { latitude: 48.0, longitude: -123.0 },
+          timestamp: 2000,
+          source: "signalk.local",
+        },
+      });
+      flushAIS();
+
+      const dp = aisState.vessels["211234567"].data["navigation.position"];
+      expect(dp?.value).toEqual({ latitude: 48.0, longitude: -123.0 });
+      expect(dp?.source).toBe("signalk.local");
+    });
+
+    it("merges different paths from different sources", () => {
+      updateAISVessel("211234567", {
+        "navigation.position": {
+          value: { latitude: 47.6, longitude: -122.3 },
+          timestamp: 1000,
+          source: "signalk.local",
+        },
+      });
+      updateAISVessel("211234567", {
+        "design.aisShipType": {
+          value: 70,
+          timestamp: 2000,
+          source: "aisstream",
+        },
+      });
+      flushAIS();
+
+      const vessel = aisState.vessels["211234567"];
+      expect(vessel.data["navigation.position"]?.source).toBe("signalk.local");
+      expect(vessel.data["design.aisShipType"]?.source).toBe("aisstream");
+    });
+
+    it("collapses older-then-newer within a single flush window", () => {
+      // First call: queue an older value into the buffer.
+      updateAISVessel("211234567", {
+        "navigation.position": {
+          value: { latitude: 0, longitude: 0 },
+          timestamp: 1000,
+          source: "aisstream",
+        },
+      });
+      // Second call before flush: newer value should replace the buffered one.
+      updateAISVessel("211234567", {
+        "navigation.position": {
+          value: { latitude: 47.6, longitude: -122.3 },
+          timestamp: 2000,
+          source: "signalk.local",
+        },
+      });
+      flushAIS();
+
+      const dp = aisState.vessels["211234567"].data["navigation.position"];
+      expect(dp?.value).toEqual({ latitude: 47.6, longitude: -122.3 });
+      expect(dp?.source).toBe("signalk.local");
+    });
+  });
+
+  describe("vesselPrimarySource", () => {
+    it("returns 'unknown' when the vessel has no data", () => {
+      expect(
+        vesselPrimarySource({ mmsi: "211234567", data: {}, lastSeen: 0 }),
+      ).toBe("unknown");
+    });
+
+    it("identifies signalk family by prefix", () => {
+      expect(
+        vesselPrimarySource({
+          mmsi: "211234567",
+          lastSeen: 0,
+          data: {
+            "navigation.position": {
+              value: { latitude: 0, longitude: 0 },
+              timestamp: 100,
+              source: "signalk.signalk-abc",
+            },
+          },
+        }),
+      ).toBe("signalk");
+    });
+
+    it("identifies nmea family by prefix", () => {
+      expect(
+        vesselPrimarySource({
+          mmsi: "211234567",
+          lastSeen: 0,
+          data: {
+            "navigation.position": {
+              value: { latitude: 0, longitude: 0 },
+              timestamp: 100,
+              source: "nmea.nmea-tcp-xyz",
+            },
+          },
+        }),
+      ).toBe("nmea");
+    });
+
+    it("identifies aisstream by exact match", () => {
+      expect(
+        vesselPrimarySource({
+          mmsi: "211234567",
+          lastSeen: 0,
+          data: {
+            "navigation.position": {
+              value: { latitude: 0, longitude: 0 },
+              timestamp: 100,
+              source: "aisstream",
+            },
+          },
+        }),
+      ).toBe("aisstream");
+    });
+
+    it("returns the family of the most-recent timestamp when sources mix", () => {
+      // Old AIS Stream + newer Signal K → Signal K wins.
+      expect(
+        vesselPrimarySource({
+          mmsi: "211234567",
+          lastSeen: 0,
+          data: {
+            "design.aisShipType": {
+              value: 70,
+              timestamp: 100,
+              source: "aisstream",
+            },
+            "navigation.position": {
+              value: { latitude: 0, longitude: 0 },
+              timestamp: 200,
+              source: "signalk.local",
+            },
+          },
+        }),
+      ).toBe("signalk");
     });
   });
 });

--- a/tests/aisstream/client.test.ts
+++ b/tests/aisstream/client.test.ts
@@ -1,0 +1,49 @@
+import { boundsToSubscription, padBounds } from "@/aisstream/client";
+
+describe("boundsToSubscription", () => {
+  it("emits a single box for non-crossing bounds", () => {
+    // West Coast US: [-130, 30, -110, 50]
+    const boxes = boundsToSubscription([-130, 30, -110, 50]);
+    expect(boxes).toEqual([[[30, -130], [50, -110]]]);
+  });
+
+  it("splits at the antimeridian (west > east)", () => {
+    // Aleutians-ish viewport: west=170, east=-170 → crosses 180°
+    const boxes = boundsToSubscription([170, 50, -170, 60]);
+    expect(boxes).toEqual([
+      [[50, 170], [60, 180]],
+      [[50, -180], [60, -170]],
+    ]);
+  });
+
+  it("clamps latitudes to ±90", () => {
+    const boxes = boundsToSubscription([-10, -95, 10, 95]);
+    expect(boxes[0][0][0]).toBe(-90);
+    expect(boxes[0][1][0]).toBe(90);
+  });
+});
+
+describe("padBounds", () => {
+  it("pads each side by factor × span", () => {
+    // 20°-wide, 10°-tall box; factor=0.5 → +10° lon, +5° lat each side.
+    const padded = padBounds([-10, 0, 10, 10], 0.5);
+    expect(padded[0]).toBeCloseTo(-20);
+    expect(padded[1]).toBeCloseTo(-5);
+    expect(padded[2]).toBeCloseTo(20);
+    expect(padded[3]).toBeCloseTo(15);
+  });
+
+  it("clamps latitudes at ±90", () => {
+    const padded = padBounds([0, 85, 10, 89], 1);
+    expect(padded[1]).toBe(-90 < 85 - 4 ? 85 - 4 : -90); // 81
+    expect(padded[3]).toBe(90); // clamped
+  });
+
+  it("wraps longitude when padding crosses the antimeridian", () => {
+    // Box near 170°E, pad pushes west of -180°.
+    const padded = padBounds([170, 0, 175, 10], 1);
+    // Original west=170, span=5, pad=5 → west=165 (no wrap), east=180 (wrap to 180)
+    expect(padded[0]).toBe(165);
+    expect(padded[2]).toBe(180);
+  });
+});

--- a/tests/aisstream/messages.test.ts
+++ b/tests/aisstream/messages.test.ts
@@ -1,0 +1,501 @@
+import type { DataPoint } from "@/instruments/hooks/useInstruments";
+import {
+  type AISStreamDecodeResult,
+  AISSTREAM_SOURCE,
+  decodeAISStreamMessage,
+} from "@/aisstream/messages";
+
+const TIME = "2022-12-29 18:22:32.318353 +0000 UTC";
+const TIME_MS = Date.parse("2022-12-29 18:22:32.318353 +0000");
+
+function expectVessel(
+  result: AISStreamDecodeResult,
+): asserts result is {
+  kind: "vessel";
+  mmsi: string;
+  paths: Record<string, DataPoint>;
+} {
+  if (result?.kind !== "vessel") {
+    throw new Error(`expected vessel result, got ${result?.kind ?? "null"}`);
+  }
+}
+
+function expectAton(
+  result: AISStreamDecodeResult,
+): asserts result is {
+  kind: "aton";
+  id: string;
+  paths: Record<string, DataPoint>;
+} {
+  if (result?.kind !== "aton") {
+    throw new Error(`expected aton result, got ${result?.kind ?? "null"}`);
+  }
+}
+
+describe("decodeAISStreamMessage", () => {
+  it("decodes a Class A PositionReport", () => {
+    const result = decodeAISStreamMessage({
+      MessageType: "PositionReport",
+      MetaData: {
+        MMSI: 245473000,
+        ShipName: "TEST VESSEL",
+        time_utc: TIME,
+      },
+      Message: {
+        PositionReport: {
+          Latitude: 51.4445,
+          Longitude: 3.5908,
+          Cog: 180,
+          Sog: 10,
+          TrueHeading: 175,
+          NavigationalStatus: 0,
+        },
+      },
+    });
+
+    expectVessel(result);
+    expect(result.mmsi).toBe("245473000");
+    const paths = result.paths;
+
+    expect(paths["navigation.position"]?.value).toEqual({
+      latitude: 51.4445,
+      longitude: 3.5908,
+    });
+    expect(paths["navigation.position"]?.timestamp).toBe(TIME_MS);
+    expect(paths["navigation.position"]?.source).toBe(AISSTREAM_SOURCE);
+
+    expect(paths["navigation.courseOverGroundTrue"]?.value).toBeCloseTo(Math.PI);
+    expect(paths["navigation.speedOverGround"]?.value).toBeCloseTo(5.14444, 4);
+    expect(paths["navigation.headingTrue"]?.value).toBeCloseTo(
+      (175 * Math.PI) / 180,
+    );
+    expect(paths["navigation.state"]?.value).toBe(0);
+    expect(paths["name"]?.value).toBe("TEST VESSEL");
+  });
+
+  it("drops TrueHeading sentinel 511", () => {
+    const result = decodeAISStreamMessage({
+      MessageType: "StandardClassBPositionReport",
+      MetaData: { MMSI: 367000980, time_utc: TIME },
+      Message: {
+        StandardClassBPositionReport: {
+          Latitude: 39.5,
+          Longitude: 2.6,
+          Cog: 210,
+          Sog: 0,
+          TrueHeading: 511,
+        },
+      },
+    });
+    expect(result?.paths["navigation.headingTrue"]).toBeUndefined();
+    expect(result?.paths["navigation.courseOverGroundTrue"]).toBeDefined();
+  });
+
+  it("decodes Class B with no static data", () => {
+    const result = decodeAISStreamMessage({
+      MessageType: "StandardClassBPositionReport",
+      MetaData: { MMSI: 367000980, ShipName: "B-VESSEL", time_utc: TIME },
+      Message: {
+        StandardClassBPositionReport: {
+          Latitude: 39.5,
+          Longitude: 2.6,
+          Cog: 0,
+          Sog: 0,
+        },
+      },
+    });
+    expectVessel(result);
+    expect(result.mmsi).toBe("367000980");
+    expect(result.paths["name"]?.value).toBe("B-VESSEL");
+    expect(result.paths["design.length"]).toBeUndefined();
+  });
+
+  it("decodes ExtendedClassBPositionReport with dimensions", () => {
+    const result = decodeAISStreamMessage({
+      MessageType: "ExtendedClassBPositionReport",
+      MetaData: { MMSI: 225111802, time_utc: TIME },
+      Message: {
+        ExtendedClassBPositionReport: {
+          Latitude: 22.31,
+          Longitude: 114.51,
+          Cog: 234.5,
+          Sog: 0,
+          TrueHeading: 511,
+          Type: 60,
+          Name: "EXT-B",
+          Dimension: { A: 10, B: 20, C: 3, D: 4 },
+        },
+      },
+    });
+    expect(result?.paths["design.length"]?.value).toBe(30);
+    expect(result?.paths["design.beam"]?.value).toBe(7);
+    expect(result?.paths["design.aisShipType"]?.value).toBe(60);
+    expect(result?.paths["name"]?.value).toBe("EXT-B");
+  });
+
+  it("decodes ShipStaticData with all fields", () => {
+    const result = decodeAISStreamMessage({
+      MessageType: "ShipStaticData",
+      MetaData: { MMSI: 257069200, ShipName: "KV FARM", time_utc: TIME },
+      Message: {
+        ShipStaticData: {
+          Type: 55,
+          CallSign: "LBHF",
+          Destination: "ROTTERDAM@@@@@@@@@",
+          ImoNumber: 9353333,
+          MaximumStaticDraught: 4.5,
+          Dimension: { A: 20, B: 27, C: 7, D: 7 },
+        },
+      },
+    });
+
+    const paths = result!.paths;
+    expect(paths["design.aisShipType"]?.value).toBe(55);
+    expect(paths["communication.callsignVhf"]?.value).toBe("LBHF");
+    expect(paths["navigation.destination"]?.value).toBe("ROTTERDAM");
+    expect(paths["registrations.imo"]?.value).toBe("9353333");
+    expect(paths["design.draft"]?.value).toBe(4.5);
+    expect(paths["design.length"]?.value).toBe(47);
+    expect(paths["design.beam"]?.value).toBe(14);
+  });
+
+  it("falls back to Date.now() when time_utc is unparseable", () => {
+    const before = Date.now();
+    const result = decodeAISStreamMessage({
+      MessageType: "PositionReport",
+      MetaData: { MMSI: 211234567, time_utc: "garbage" },
+      Message: {
+        PositionReport: { Latitude: 47.6, Longitude: -122.3 },
+      },
+    });
+    const after = Date.now();
+    const ts = result!.paths["navigation.position"]!.timestamp;
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  it("returns null when MMSI is missing", () => {
+    expect(
+      decodeAISStreamMessage({
+        MessageType: "PositionReport",
+        MetaData: {},
+        Message: { PositionReport: { Latitude: 47.6, Longitude: -122.3 } },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when no decodable fields are present", () => {
+    expect(
+      decodeAISStreamMessage({
+        MessageType: "BaseStationReport",
+        MetaData: { MMSI: 211234567, time_utc: TIME },
+        Message: {},
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores ImoNumber when zero", () => {
+    const result = decodeAISStreamMessage({
+      MessageType: "ShipStaticData",
+      MetaData: { MMSI: 211234567, time_utc: TIME },
+      Message: {
+        ShipStaticData: { Type: 70, ImoNumber: 0 },
+      },
+    });
+    expect(result?.paths["registrations.imo"]).toBeUndefined();
+  });
+
+  it("extracts RateOfTurn as rad/s", () => {
+    // 60 deg/min → 1 deg/s → π/180 rad/s
+    const result = decodeAISStreamMessage({
+      MessageType: "PositionReport",
+      MetaData: { MMSI: 211234567, time_utc: TIME },
+      Message: {
+        PositionReport: {
+          Latitude: 47.6,
+          Longitude: -122.3,
+          RateOfTurn: 60,
+        },
+      },
+    });
+    expect(result?.paths["navigation.rateOfTurn"]?.value).toBeCloseTo(
+      Math.PI / 180,
+      6,
+    );
+  });
+
+  it("drops RateOfTurn sentinel -128", () => {
+    const result = decodeAISStreamMessage({
+      MessageType: "PositionReport",
+      MetaData: { MMSI: 211234567, time_utc: TIME },
+      Message: {
+        PositionReport: {
+          Latitude: 47.6,
+          Longitude: -122.3,
+          RateOfTurn: -128,
+        },
+      },
+    });
+    expect(result?.paths["navigation.rateOfTurn"]).toBeUndefined();
+  });
+
+  it("formats ETA as MM-DDTHH:MM with zero-padding", () => {
+    const result = decodeAISStreamMessage({
+      MessageType: "ShipStaticData",
+      MetaData: { MMSI: 211234567, time_utc: TIME },
+      Message: {
+        ShipStaticData: {
+          Type: 70,
+          Eta: { Month: 3, Day: 7, Hour: 14, Minute: 5 },
+        },
+      },
+    });
+    expect(result?.paths["navigation.eta"]?.value).toBe("03-07T14:05");
+  });
+
+  it("drops ETA when Month or Day is zero (AIS 'not available')", () => {
+    const result = decodeAISStreamMessage({
+      MessageType: "ShipStaticData",
+      MetaData: { MMSI: 211234567, time_utc: TIME },
+      Message: {
+        ShipStaticData: {
+          Type: 70,
+          Eta: { Month: 0, Day: 0, Hour: 0, Minute: 0 },
+        },
+      },
+    });
+    expect(result?.paths["navigation.eta"]).toBeUndefined();
+  });
+
+  it("falls back to MetaData position when inner message lacks one", () => {
+    const result = decodeAISStreamMessage({
+      MessageType: "ShipStaticData",
+      MetaData: {
+        MMSI: 211234567,
+        latitude: 47.6,
+        longitude: -122.3,
+        time_utc: TIME,
+      },
+      Message: {
+        ShipStaticData: { Type: 70, CallSign: "WDA1234" },
+      },
+    });
+    expect(result?.paths["navigation.position"]?.value).toEqual({
+      latitude: 47.6,
+      longitude: -122.3,
+    });
+  });
+
+  it("does not overwrite inner-message position with MetaData", () => {
+    // PositionReport has Lat/Lng; MetaData also has them. Inner wins.
+    const result = decodeAISStreamMessage({
+      MessageType: "PositionReport",
+      MetaData: {
+        MMSI: 211234567,
+        latitude: 0,
+        longitude: 0,
+        time_utc: TIME,
+      },
+      Message: {
+        PositionReport: { Latitude: 47.6, Longitude: -122.3 },
+      },
+    });
+    expect(result?.paths["navigation.position"]?.value).toEqual({
+      latitude: 47.6,
+      longitude: -122.3,
+    });
+  });
+
+  it("ignores MetaData (0, 0) null-island sentinel", () => {
+    const result = decodeAISStreamMessage({
+      MessageType: "ShipStaticData",
+      MetaData: { MMSI: 211234567, latitude: 0, longitude: 0, time_utc: TIME },
+      Message: { ShipStaticData: { Type: 70 } },
+    });
+    expect(result?.paths["navigation.position"]).toBeUndefined();
+  });
+
+  it("drops empty trimmed strings", () => {
+    const result = decodeAISStreamMessage({
+      MessageType: "ShipStaticData",
+      MetaData: { MMSI: 211234567, ShipName: "@@@@@@@@@@", time_utc: TIME },
+      Message: { ShipStaticData: { Type: 70, Destination: "@@@@@" } },
+    });
+    expect(result?.paths["name"]).toBeUndefined();
+    expect(result?.paths["navigation.destination"]).toBeUndefined();
+  });
+
+  describe("StaticDataReport (Type 24)", () => {
+    it("decodes Part A (name only)", () => {
+      const result = decodeAISStreamMessage({
+        MessageType: "StaticDataReport",
+        MetaData: { MMSI: 367000980, time_utc: TIME },
+        Message: {
+          StaticDataReport: {
+            PartNumber: false,
+            ReportA: { Name: "CLASS B BOAT@@" },
+          },
+        },
+      });
+      expectVessel(result);
+      expect(result.paths["name"]?.value).toBe("CLASS B BOAT");
+    });
+
+    it("decodes Part B (ship type, call sign, dimensions)", () => {
+      const result = decodeAISStreamMessage({
+        MessageType: "StaticDataReport",
+        MetaData: { MMSI: 367000980, time_utc: TIME },
+        Message: {
+          StaticDataReport: {
+            PartNumber: true,
+            ReportB: {
+              ShipType: 37,
+              CallSign: "WDF1234",
+              Dimension: { A: 4, B: 6, C: 1, D: 2 },
+            },
+          },
+        },
+      });
+      expectVessel(result);
+      expect(result.paths["design.aisShipType"]?.value).toBe(37);
+      expect(result.paths["communication.callsignVhf"]?.value).toBe("WDF1234");
+      expect(result.paths["design.length"]?.value).toBe(10);
+      expect(result.paths["design.beam"]?.value).toBe(3);
+    });
+  });
+
+  describe("AidsToNavigationReport (Type 21)", () => {
+    it("decodes AtoN with all fields and routes to the AtoN store", () => {
+      const result = decodeAISStreamMessage({
+        MessageType: "AidsToNavigationReport",
+        MetaData: { MMSI: 993661302, time_utc: TIME },
+        Message: {
+          AidsToNavigationReport: {
+            Type: 5,
+            Name: "BUOY 12",
+            Latitude: 47.6,
+            Longitude: -122.3,
+            OffPosition: false,
+            VirtualAtoN: true,
+          },
+        },
+      });
+      expectAton(result);
+      expect(result.id).toBe("993661302");
+      expect(result.paths["mmsi"]?.value).toBe("993661302");
+      expect(result.paths["atonType"]?.value).toBe(5);
+      expect(result.paths["name"]?.value).toBe("BUOY 12");
+      expect(result.paths["navigation.position"]?.value).toEqual({
+        latitude: 47.6,
+        longitude: -122.3,
+      });
+      // Encoded as 1/0 since DataPoint.value doesn't include boolean today.
+      expect(result.paths["offPosition"]?.value).toBe(0);
+      expect(result.paths["virtual"]?.value).toBe(1);
+    });
+
+    it("concatenates Name + NameExtension before trimming", () => {
+      // Type 21 Name is 14 chars + an optional NameExtension. If the base name
+      // is exactly 14 chars and the extension carries the rest, trimming the
+      // base alone would lose the extension.
+      const result = decodeAISStreamMessage({
+        MessageType: "AidsToNavigationReport",
+        MetaData: { MMSI: 993661302, time_utc: TIME },
+        Message: {
+          AidsToNavigationReport: {
+            Type: 5,
+            Name: "LIGHTHOUSE TIL",
+            NameExtension: "LAMOOK HEAD",
+            Latitude: 45.94,
+            Longitude: -123.97,
+          },
+        },
+      });
+      expectAton(result);
+      expect(result.paths["name"]?.value).toBe("LIGHTHOUSE TILLAMOOK HEAD");
+    });
+
+    it("falls back to MetaData position when inner lacks one", () => {
+      const result = decodeAISStreamMessage({
+        MessageType: "AidsToNavigationReport",
+        MetaData: {
+          MMSI: 993661302,
+          latitude: 47.6,
+          longitude: -122.3,
+          time_utc: TIME,
+        },
+        Message: {
+          AidsToNavigationReport: { Type: 5, Name: "BUOY 12" },
+        },
+      });
+      expectAton(result);
+      expect(result.paths["navigation.position"]?.value).toEqual({
+        latitude: 47.6,
+        longitude: -122.3,
+      });
+    });
+  });
+
+  describe("LongRangeAisBroadcastMessage (Type 27)", () => {
+    it("decodes via the same paths as PositionReport", () => {
+      const result = decodeAISStreamMessage({
+        MessageType: "LongRangeAisBroadcastMessage",
+        MetaData: { MMSI: 211234567, time_utc: TIME },
+        Message: {
+          LongRangeAisBroadcastMessage: {
+            Latitude: -34.5,
+            Longitude: 18.4,
+            Cog: 90,
+            Sog: 12,
+            NavigationalStatus: 0,
+          },
+        },
+      });
+      expectVessel(result);
+      expect(result.paths["navigation.position"]?.value).toEqual({
+        latitude: -34.5,
+        longitude: 18.4,
+      });
+      expect(result.paths["navigation.courseOverGroundTrue"]?.value).toBeCloseTo(
+        Math.PI / 2,
+      );
+      expect(result.paths["navigation.speedOverGround"]?.value).toBeCloseTo(
+        12 * 0.514444,
+        4,
+      );
+      expect(result.paths["navigation.state"]?.value).toBe(0);
+    });
+  });
+
+  describe("StandardSearchAndRescueAircraftReport (Type 9)", () => {
+    it("decodes SAR aircraft position", () => {
+      const result = decodeAISStreamMessage({
+        MessageType: "StandardSearchAndRescueAircraftReport",
+        MetaData: {
+          MMSI: 111232450,
+          ShipName: "USCG HELO",
+          time_utc: TIME,
+        },
+        Message: {
+          StandardSearchAndRescueAircraftReport: {
+            Latitude: 36.5,
+            Longitude: -75.0,
+            Cog: 180,
+            Sog: 120,
+          },
+        },
+      });
+      expectVessel(result);
+      expect(result.mmsi).toBe("111232450");
+      expect(result.paths["name"]?.value).toBe("USCG HELO");
+      expect(result.paths["navigation.position"]?.value).toEqual({
+        latitude: 36.5,
+        longitude: -75.0,
+      });
+      expect(result.paths["navigation.speedOverGround"]?.value).toBeCloseTo(
+        120 * 0.514444,
+        3,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Users without their own AIS receiver — or anyone looking beyond VHF range — now see worldwide traffic from aisstream.io scoped to the current viewport. Enabled by default; the Connections sheet has a toggle to disable it for users who'd rather not pay the cellular cost. The bundled API key ships via EXPO_PUBLIC_AISSTREAM_API_KEY (see .env.example).